### PR TITLE
Fix the location for socket-communication rule

### DIFF
--- a/default/generated/cloud-readiness/12-socket-communication.windup.yaml
+++ b/default/generated/cloud-readiness/12-socket-communication.windup.yaml
@@ -17,16 +17,16 @@
   when:
     or:
     - java.referenced:
-        location: PACKAGE
+        location: IMPORT
         pattern: java.net.(Socket|MulticastSocket|DatagramSocket|InetSocketAddress)*
     - java.referenced:
-        location: PACKAGE
+        location: IMPORT
         pattern: java.net.ServerSocket*
     - java.referenced:
-        location: PACKAGE
+        location: IMPORT
         pattern: java.nio.channels.AsynchronousServerSocketChannel*
     - java.referenced:
-        location: PACKAGE
+        location: IMPORT
         pattern: java.nio.channels.ServerSocketChannel*
 - category: optional
   customVariables:
@@ -49,5 +49,5 @@
   ruleID: socket-communication-00001
   when:
     java.referenced:
-      location: PACKAGE
+      location: IMPORT
       pattern: java.nio.channels.(NetworkChannel|MulticastChannel|DatagramChannel|AsynchronousSocketChannel|SocketChannel)*


### PR DESCRIPTION
This PR contains updates to the socket-communication-windup rules to correctly identify the import statements.