### PR TITLE
Add missing descriptions and script to generate them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.venv

--- a/default/generated/azure/37-jetty-to-azure-external-resources.windup.yaml
+++ b/default/generated/azure/37-jetty-to-azure-external-resources.windup.yaml
@@ -10,7 +10,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
 
 # See the License for the specific language governing permissions and 
-# limitations under the License. - category: optional
+# limitations under the License. 
+- category: optional
   customVariables: []
   description: External resources found in configuration file
   effort: 5

--- a/default/generated/technology-usage/02-web-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/02-web-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: JSF
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - JSF
 - customVariables: []
+  description: JSP
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - JSP
 - customVariables: []
+  description: WebXML
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - WebXML
 - customVariables: []
+  description: WebSocket
   labels:
   - konveyor.io/include=always
   links: []
@@ -60,6 +64,7 @@
     - builtin.hasTags:
       - Applet
 - customVariables: []
+  description: JNLP
   labels:
   - konveyor.io/include=always
   links: []
@@ -72,6 +77,7 @@
     builtin.hasTags:
     - JNLP
 - customVariables: []
+  description: JNLP
   labels:
   - konveyor.io/include=always
   links: []
@@ -84,6 +90,7 @@
     builtin.hasTags:
     - JNLP
 - customVariables: []
+  description: Swing
   labels:
   - konveyor.io/include=always
   links: []
@@ -96,6 +103,7 @@
     builtin.hasTags:
     - Swing
 - customVariables: []
+  description: MiGLayout
   labels:
   - konveyor.io/include=always
   links: []
@@ -108,6 +116,7 @@
     builtin.hasTags:
     - MiGLayout
 - customVariables: []
+  description: JGoodies
   labels:
   - konveyor.io/include=always
   links: []
@@ -120,6 +129,7 @@
     builtin.hasTags:
     - JGoodies
 - customVariables: []
+  description: FormLayoutMaker
   labels:
   - konveyor.io/include=always
   links: []
@@ -132,6 +142,7 @@
     builtin.hasTags:
     - FormLayoutMaker
 - customVariables: []
+  description: Magicgrouplayout
   labels:
   - konveyor.io/include=always
   links: []
@@ -144,6 +155,7 @@
     builtin.hasTags:
     - Magicgrouplayout
 - customVariables: []
+  description: SWT
   labels:
   - konveyor.io/include=always
   links: []
@@ -156,6 +168,7 @@
     builtin.hasTags:
     - SWT
 - customVariables: []
+  description: JavaFX
   labels:
   - konveyor.io/include=always
   links: []
@@ -168,6 +181,7 @@
     builtin.hasTags:
     - JavaFX
 - customVariables: []
+  description: Eclipse RCP
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/04-test-frameworks-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/04-test-frameworks-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: EasyMock
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - EasyMock
 - customVariables: []
+  description: PowerMock
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - PowerMock
 - customVariables: []
+  description: Mockito
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Mockito
 - customVariables: []
+  description: TestNG
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - TestNG
 - customVariables: []
+  description: Hamcrest
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - Hamcrest
 - customVariables: []
+  description: Spock
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - Spock
 - customVariables: []
+  description: XMLUnit
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - XMLUnit
 - customVariables: []
+  description: Akka Testkit
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - Akka Testkit
 - customVariables: []
+  description: REST Assured
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - REST Assured
 - customVariables: []
+  description: DbUnit
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - DbUnit
 - customVariables: []
+  description: Mule Functional Test Framework
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - Mule Functional Test Framework
 - customVariables: []
+  description: Guava Testing
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - Guava Testing
 - customVariables: []
+  description: RandomizedTesting Runner
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - RandomizedTesting Runner
 - customVariables: []
+  description: HttpUnit
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - HttpUnit
 - customVariables: []
+  description: JCunit
   labels:
   - konveyor.io/include=always
   links: []
@@ -179,6 +194,7 @@
     builtin.hasTags:
     - JCunit
 - customVariables: []
+  description: JPA Matchers
   labels:
   - konveyor.io/include=always
   links: []
@@ -191,6 +207,7 @@
     builtin.hasTags:
     - JPA Matchers
 - customVariables: []
+  description: MultithreadedTC
   labels:
   - konveyor.io/include=always
   links: []
@@ -203,6 +220,7 @@
     builtin.hasTags:
     - MultithreadedTC
 - customVariables: []
+  description: Specsy
   labels:
   - konveyor.io/include=always
   links: []
@@ -215,6 +233,7 @@
     builtin.hasTags:
     - Specsy
 - customVariables: []
+  description: JFunk
   labels:
   - konveyor.io/include=always
   links: []
@@ -227,6 +246,7 @@
     builtin.hasTags:
     - JFunk
 - customVariables: []
+  description: Restito
   labels:
   - konveyor.io/include=always
   links: []
@@ -239,6 +259,7 @@
     builtin.hasTags:
     - Restito
 - customVariables: []
+  description: Test Interface
   labels:
   - konveyor.io/include=always
   links: []
@@ -251,6 +272,7 @@
     builtin.hasTags:
     - Test Interface
 - customVariables: []
+  description: Play Test
   labels:
   - konveyor.io/include=always
   links: []
@@ -263,6 +285,7 @@
     builtin.hasTags:
     - Play Test
 - customVariables: []
+  description: Arquillian
   labels:
   - konveyor.io/include=always
   links: []
@@ -275,6 +298,7 @@
     builtin.hasTags:
     - Arquillian
 - customVariables: []
+  description: Cactus
   labels:
   - konveyor.io/include=always
   links: []
@@ -287,6 +311,7 @@
     builtin.hasTags:
     - Cactus
 - customVariables: []
+  description: Concordion
   labels:
   - konveyor.io/include=always
   links: []
@@ -299,6 +324,7 @@
     builtin.hasTags:
     - Concordion
 - customVariables: []
+  description: Cucumber
   labels:
   - konveyor.io/include=always
   links: []
@@ -311,6 +337,7 @@
     builtin.hasTags:
     - Cucumber
 - customVariables: []
+  description: EtlUnit
   labels:
   - konveyor.io/include=always
   links: []
@@ -323,6 +350,7 @@
     builtin.hasTags:
     - EtlUnit
 - customVariables: []
+  description: HavaRunner
   labels:
   - konveyor.io/include=always
   links: []
@@ -335,6 +363,7 @@
     builtin.hasTags:
     - HavaRunner
 - customVariables: []
+  description: JBehave
   labels:
   - konveyor.io/include=always
   links: []
@@ -347,6 +376,7 @@
     builtin.hasTags:
     - JBehave
 - customVariables: []
+  description: JMock
   labels:
   - konveyor.io/include=always
   links: []
@@ -359,6 +389,7 @@
     builtin.hasTags:
     - JMock
 - customVariables: []
+  description: JMockit
   labels:
   - konveyor.io/include=always
   links: []
@@ -371,6 +402,7 @@
     builtin.hasTags:
     - JMockit
 - customVariables: []
+  description: Jukito
   labels:
   - konveyor.io/include=always
   links: []
@@ -383,6 +415,7 @@
     builtin.hasTags:
     - Jukito
 - customVariables: []
+  description: Needle
   labels:
   - konveyor.io/include=always
   links: []
@@ -395,6 +428,7 @@
     builtin.hasTags:
     - Needle
 - customVariables: []
+  description: OpenPojo
   labels:
   - konveyor.io/include=always
   links: []
@@ -407,6 +441,7 @@
     builtin.hasTags:
     - OpenPojo
 - customVariables: []
+  description: Unitils
   labels:
   - konveyor.io/include=always
   links: []
@@ -419,6 +454,7 @@
     builtin.hasTags:
     - Unitils
 - customVariables: []
+  description: Spring Test
   labels:
   - konveyor.io/include=always
   links: []
@@ -431,6 +467,7 @@
     builtin.hasTags:
     - Spring Test
 - customVariables: []
+  description: JUnit
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/07-security-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/07-security-technology-usage.windup.yaml
@@ -27,6 +27,7 @@
         namespaces: {}
         xpath: //*[local-name() = 'login-config']/*[local-name() = 'realm']
 - customVariables: []
+  description: Spring Security
   labels:
   - konveyor.io/include=always
   links: []
@@ -39,6 +40,7 @@
     builtin.hasTags:
     - Spring Security
 - customVariables: []
+  description: Apache Shiro
   labels:
   - konveyor.io/include=always
   links: []
@@ -51,6 +53,7 @@
     builtin.hasTags:
     - Apache Shiro
 - customVariables: []
+  description: Hdiv
   labels:
   - konveyor.io/include=always
   links: []
@@ -63,6 +66,7 @@
     builtin.hasTags:
     - Hdiv
 - customVariables: []
+  description: OACC
   labels:
   - konveyor.io/include=always
   links: []
@@ -75,6 +79,7 @@
     builtin.hasTags:
     - OACC
 - customVariables: []
+  description: PicketLink
   labels:
   - konveyor.io/include=always
   links: []
@@ -87,6 +92,7 @@
     builtin.hasTags:
     - PicketLink
 - customVariables: []
+  description: PicketBox
   labels:
   - konveyor.io/include=always
   links: []
@@ -99,6 +105,7 @@
     builtin.hasTags:
     - PicketBox
 - customVariables: []
+  description: Keyczar
   labels:
   - konveyor.io/include=always
   links: []
@@ -111,6 +118,7 @@
     builtin.hasTags:
     - Keyczar
 - customVariables: []
+  description: XACML
   labels:
   - konveyor.io/include=always
   links: []
@@ -123,6 +131,7 @@
     builtin.hasTags:
     - XACML
 - customVariables: []
+  description: SAML
   labels:
   - konveyor.io/include=always
   links: []
@@ -135,6 +144,7 @@
     builtin.hasTags:
     - SAML
 - customVariables: []
+  description: Bouncy Castle
   labels:
   - konveyor.io/include=always
   links: []
@@ -147,6 +157,7 @@
     builtin.hasTags:
     - Bouncy Castle
 - customVariables: []
+  description: Jasypt
   labels:
   - konveyor.io/include=always
   links: []
@@ -159,6 +170,7 @@
     builtin.hasTags:
     - Jasypt
 - customVariables: []
+  description: Apache Santuario
   labels:
   - konveyor.io/include=always
   links: []
@@ -171,6 +183,7 @@
     builtin.hasTags:
     - Apache Santuario
 - customVariables: []
+  description: SSL
   labels:
   - konveyor.io/include=always
   links: []
@@ -183,6 +196,7 @@
     builtin.hasTags:
     - SSL
 - customVariables: []
+  description: Vlad
   labels:
   - konveyor.io/include=always
   links: []
@@ -195,6 +209,7 @@
     builtin.hasTags:
     - Vlad
 - customVariables: []
+  description: Apache Commons Validator
   labels:
   - konveyor.io/include=always
   links: []
@@ -207,6 +222,7 @@
     builtin.hasTags:
     - Apache Commons Validator
 - customVariables: []
+  description: OWASP ESAPI
   labels:
   - konveyor.io/include=always
   links: []
@@ -219,6 +235,7 @@
     builtin.hasTags:
     - OWASP ESAPI
 - customVariables: []
+  description: WSS4J
   labels:
   - konveyor.io/include=always
   links: []
@@ -231,6 +248,7 @@
     builtin.hasTags:
     - WSS4J
 - customVariables: []
+  description: OpenSAML
   labels:
   - konveyor.io/include=always
   links: []
@@ -243,6 +261,7 @@
     builtin.hasTags:
     - OpenSAML
 - customVariables: []
+  description: OTR4J
   labels:
   - konveyor.io/include=always
   links: []
@@ -255,6 +274,7 @@
     builtin.hasTags:
     - OTR4J
 - customVariables: []
+  description: OWASP CSRF Guard
   labels:
   - konveyor.io/include=always
   links: []
@@ -267,6 +287,7 @@
     builtin.hasTags:
     - OWASP CSRF Guard
 - customVariables: []
+  description: OAUTH
   labels:
   - konveyor.io/include=always
   links: []
@@ -279,6 +300,7 @@
     builtin.hasTags:
     - OAUTH
 - customVariables: []
+  description: Acegi Security
   labels:
   - konveyor.io/include=always
   links: []
@@ -291,6 +313,7 @@
     builtin.hasTags:
     - Acegi Security
 - customVariables: []
+  description: JSecurity
   labels:
   - konveyor.io/include=always
   links: []
@@ -303,6 +326,7 @@
     builtin.hasTags:
     - JSecurity
 - customVariables: []
+  description: AcrIS Security
   labels:
   - konveyor.io/include=always
   links: []
@@ -315,6 +339,7 @@
     builtin.hasTags:
     - AcrIS Security
 - customVariables: []
+  description: Trunk JGuard
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/09-observability-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/09-observability-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Spring Boot Actuator
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Spring Boot Actuator
 - customVariables: []
+  description: Spring JMX
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/10-non-xml-rules-technology-usage.rhamt.yaml
+++ b/default/generated/technology-usage/10-non-xml-rules-technology-usage.rhamt.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: EJB XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - EJB XML
 - customVariables: []
+  description: Hibernate Cfg
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - Hibernate Cfg
 - customVariables: []
+  description: Hibernate Mapping
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Hibernate Mapping
 - customVariables: []
+  description: JBoss EJB XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - JBoss EJB XML
 - customVariables: []
+  description: JBoss Web XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - JBoss Web XML
 - customVariables: []
+  description: JDBC
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - JDBC
 - customVariables: []
+  description: JPA XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - JPA XML
 - customVariables: []
+  description: Orion EJB XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - Orion EJB XML
 - customVariables: []
+  description: Orion Web XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - Orion Web XML
 - customVariables: []
+  description: Properties
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - Properties
 - customVariables: []
+  description: Seam
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - Seam
 - customVariables: []
+  description: WebLogic Web XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - WebLogic Web XML
 - customVariables: []
+  description: WebSphere EJB
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - WebSphere EJB
 - customVariables: []
+  description: WebSphere EJB Ext
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - WebSphere EJB Ext
 - customVariables: []
+  description: WebSphere Web XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -179,6 +194,7 @@
     builtin.hasTags:
     - WebSphere Web XML
 - customVariables: []
+  description: WebSphere WS Binding
   labels:
   - konveyor.io/include=always
   links: []
@@ -191,6 +207,7 @@
     builtin.hasTags:
     - WebSphere WS Binding
 - customVariables: []
+  description: WebSphere WS Extension
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/12-mvc-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/12-mvc-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Apache Wicket
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Apache Wicket
 - customVariables: []
+  description: Apache Struts
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - Apache Struts
 - customVariables: []
+  description: Spring MVC
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Spring MVC
 - customVariables: []
+  description: GWT
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - GWT
 - customVariables: []
+  description: MyFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - MyFaces
 - customVariables: []
+  description: RichFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - RichFaces
 - customVariables: []
+  description: JSF
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - JSF
 - customVariables: []
+  description: Apache Tapestry
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - Apache Tapestry
 - customVariables: []
+  description: Stripes
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - Stripes
 - customVariables: []
+  description: Spark
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - Spark
 - customVariables: []
+  description: Vaadin
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - Vaadin
 - customVariables: []
+  description: Grails
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - Grails
 - customVariables: []
+  description: Play
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - Play
 - customVariables: []
+  description: Oracle ADF
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - Oracle ADF
 - customVariables: []
+  description: PrimeFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -179,6 +194,7 @@
     builtin.hasTags:
     - PrimeFaces
 - customVariables: []
+  description: JSTL
   labels:
   - konveyor.io/include=always
   links: []
@@ -191,6 +207,7 @@
     builtin.hasTags:
     - JSTL
 - customVariables: []
+  description: OpenFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -203,6 +220,7 @@
     builtin.hasTags:
     - OpenFaces
 - customVariables: []
+  description: JFreeChart
   labels:
   - konveyor.io/include=always
   links: []
@@ -215,6 +233,7 @@
     builtin.hasTags:
     - JFreeChart
 - customVariables: []
+  description: BootsFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -227,6 +246,7 @@
     builtin.hasTags:
     - BootsFaces
 - customVariables: []
+  description: ICEfaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -239,6 +259,7 @@
     builtin.hasTags:
     - ICEfaces
 - customVariables: []
+  description: BabbageFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -251,6 +272,7 @@
     builtin.hasTags:
     - BabbageFaces
 - customVariables: []
+  description: Portlet
   labels:
   - konveyor.io/include=always
   links: []
@@ -263,6 +285,7 @@
     builtin.hasTags:
     - Portlet
 - customVariables: []
+  description: AngularFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -275,6 +298,7 @@
     builtin.hasTags:
     - AngularFaces
 - customVariables: []
+  description: LiferayFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -287,6 +311,7 @@
     builtin.hasTags:
     - LiferayFaces
 - customVariables: []
+  description: Liferay
   labels:
   - konveyor.io/include=always
   links: []
@@ -299,6 +324,7 @@
     builtin.hasTags:
     - Liferay
 - customVariables: []
+  description: ButterFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -311,6 +337,7 @@
     builtin.hasTags:
     - ButterFaces
 - customVariables: []
+  description: HighFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -323,6 +350,7 @@
     builtin.hasTags:
     - HighFaces
 - customVariables: []
+  description: TieFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -335,6 +363,7 @@
     builtin.hasTags:
     - TieFaces
 - customVariables: []
+  description: OmniFaces
   labels:
   - konveyor.io/include=always
   links: []
@@ -347,6 +376,7 @@
     builtin.hasTags:
     - OmniFaces
 - customVariables: []
+  description: UberFire
   labels:
   - konveyor.io/include=always
   links: []
@@ -359,6 +389,7 @@
     builtin.hasTags:
     - UberFire
 - customVariables: []
+  description: Velocity
   labels:
   - konveyor.io/include=always
   links: []
@@ -371,6 +402,7 @@
     builtin.hasTags:
     - Velocity
 - customVariables: []
+  description: Thymeleaf
   labels:
   - konveyor.io/include=always
   links: []
@@ -383,6 +415,7 @@
     builtin.hasTags:
     - Thymeleaf
 - customVariables: []
+  description: FreeMarker
   labels:
   - konveyor.io/include=always
   links: []
@@ -395,6 +428,7 @@
     builtin.hasTags:
     - FreeMarker
 - customVariables: []
+  description: ANTLR StringTemplate
   labels:
   - konveyor.io/include=always
   links: []
@@ -407,6 +441,7 @@
     builtin.hasTags:
     - ANTLR StringTemplate
 - customVariables: []
+  description: Handlebars
   labels:
   - konveyor.io/include=always
   links: []
@@ -419,6 +454,7 @@
     builtin.hasTags:
     - Handlebars
 - customVariables: []
+  description: JMustache
   labels:
   - konveyor.io/include=always
   links: []
@@ -431,6 +467,7 @@
     builtin.hasTags:
     - JMustache
 - customVariables: []
+  description: Jamon
   labels:
   - konveyor.io/include=always
   links: []
@@ -443,6 +480,7 @@
     builtin.hasTags:
     - Jamon
 - customVariables: []
+  description: Twirl
   labels:
   - konveyor.io/include=always
   links: []
@@ -455,6 +493,7 @@
     builtin.hasTags:
     - Twirl
 - customVariables: []
+  description: Scalate
   labels:
   - konveyor.io/include=always
   links: []
@@ -467,6 +506,7 @@
     builtin.hasTags:
     - Scalate
 - customVariables: []
+  description: Rythm Template Engine
   labels:
   - konveyor.io/include=always
   links: []
@@ -479,6 +519,7 @@
     builtin.hasTags:
     - Rythm Template Engine
 - customVariables: []
+  description: Trimou
   labels:
   - konveyor.io/include=always
   links: []
@@ -491,6 +532,7 @@
     builtin.hasTags:
     - Trimou
 - customVariables: []
+  description: Jetbrick Template
   labels:
   - konveyor.io/include=always
   links: []
@@ -503,6 +545,7 @@
     builtin.hasTags:
     - Jetbrick Template
 - customVariables: []
+  description: Chunk Templates
   labels:
   - konveyor.io/include=always
   links: []
@@ -515,6 +558,7 @@
     builtin.hasTags:
     - Chunk Templates
 - customVariables: []
+  description: JSilver
   labels:
   - konveyor.io/include=always
   links: []
@@ -527,6 +571,7 @@
     builtin.hasTags:
     - JSilver
 - customVariables: []
+  description: Water Template Engine
   labels:
   - konveyor.io/include=always
   links: []
@@ -539,6 +584,7 @@
     builtin.hasTags:
     - Water Template Engine
 - customVariables: []
+  description: Ickenham
   labels:
   - konveyor.io/include=always
   links: []
@@ -551,6 +597,7 @@
     builtin.hasTags:
     - Ickenham
 - customVariables: []
+  description: Mixer
   labels:
   - konveyor.io/include=always
   links: []
@@ -563,6 +610,7 @@
     builtin.hasTags:
     - Mixer
 - customVariables: []
+  description: Webmacro
   labels:
   - konveyor.io/include=always
   links: []
@@ -575,6 +623,7 @@
     builtin.hasTags:
     - Webmacro
 - customVariables: []
+  description: DVSL
   labels:
   - konveyor.io/include=always
   links: []
@@ -587,6 +636,7 @@
     builtin.hasTags:
     - DVSL
 - customVariables: []
+  description: Snippetory Template Engine
   labels:
   - konveyor.io/include=always
   links: []
@@ -599,6 +649,7 @@
     builtin.hasTags:
     - Snippetory Template Engine
 - customVariables: []
+  description: Anakia
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/14-markup-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/14-markup-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Spring Boot Flo
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/16-logging-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/16-logging-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Apache Log4J
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Apache Log4J
 - customVariables: []
+  description: Apache Commons Logging
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - Apache Commons Logging
 - customVariables: []
+  description: SLF4J
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - SLF4J
 - customVariables: []
+  description: tinylog
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - tinylog
 - customVariables: []
+  description: Logback
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - Logback
 - customVariables: []
+  description: Logging to file system
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - Logging to file system
 - customVariables: []
+  description: Logging to Socket Handler
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - Logging to Socket Handler
 - customVariables: []
+  description: JBoss logging
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - JBoss logging
 - customVariables: []
+  description: Monolog
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - Monolog
 - customVariables: []
+  description: Jcabi Log
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - Jcabi Log
 - customVariables: []
+  description: NLOG4J
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - NLOG4J
 - customVariables: []
+  description: Log4s
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - Log4s
 - customVariables: []
+  description: Kotlin Logging
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - Kotlin Logging
 - customVariables: []
+  description: Airlift Log Manager
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - Airlift Log Manager
 - customVariables: []
+  description: MinLog
   labels:
   - konveyor.io/include=always
   links: []
@@ -179,6 +194,7 @@
     builtin.hasTags:
     - MinLog
 - customVariables: []
+  description: Logging Utils
   labels:
   - konveyor.io/include=always
   links: []
@@ -191,6 +207,7 @@
     builtin.hasTags:
     - Logging Utils
 - customVariables: []
+  description: OCPsoft Logging Utils
   labels:
   - konveyor.io/include=always
   links: []
@@ -203,6 +220,7 @@
     builtin.hasTags:
     - OCPsoft Logging Utils
 - customVariables: []
+  description: Scribe
   labels:
   - konveyor.io/include=always
   links: []
@@ -215,6 +233,7 @@
     builtin.hasTags:
     - Scribe
 - customVariables: []
+  description: GFC Logging
   labels:
   - konveyor.io/include=always
   links: []
@@ -227,6 +246,7 @@
     builtin.hasTags:
     - GFC Logging
 - customVariables: []
+  description: Blitz4j
   labels:
   - konveyor.io/include=always
   links: []
@@ -239,6 +259,7 @@
     builtin.hasTags:
     - Blitz4j
 - customVariables: []
+  description: Avalon Logkit
   labels:
   - konveyor.io/include=always
   links: []
@@ -251,6 +272,7 @@
     builtin.hasTags:
     - Avalon Logkit
 - customVariables: []
+  description: KLogger
   labels:
   - konveyor.io/include=always
   links: []
@@ -263,6 +285,7 @@
     builtin.hasTags:
     - KLogger
 - customVariables: []
+  description: Lumberjack
   labels:
   - konveyor.io/include=always
   links: []
@@ -275,6 +298,7 @@
     builtin.hasTags:
     - Lumberjack
 - customVariables: []
+  description: Log.io
   labels:
   - konveyor.io/include=always
   links: []
@@ -287,6 +311,7 @@
     builtin.hasTags:
     - Log.io
 - customVariables: []
+  description: OPS4J Pax Logging Service
   labels:
   - konveyor.io/include=always
   links: []
@@ -299,6 +324,7 @@
     builtin.hasTags:
     - OPS4J Pax Logging Service
 - customVariables: []
+  description: OW2 Log Util
   labels:
   - konveyor.io/include=always
   links: []
@@ -311,6 +337,7 @@
     builtin.hasTags:
     - OW2 Log Util
 - customVariables: []
+  description: Twitter Util Logging
   labels:
   - konveyor.io/include=always
   links: []
@@ -323,6 +350,7 @@
     builtin.hasTags:
     - Twitter Util Logging
 - customVariables: []
+  description: Composite Logging JCL
   labels:
   - konveyor.io/include=always
   links: []
@@ -335,6 +363,7 @@
     builtin.hasTags:
     - Composite Logging JCL
 - customVariables: []
+  description: Apache Flume
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/18-jta-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/18-jta-technology-usage.windup.yaml
@@ -10,6 +10,7 @@
   when:
     or: []
 - customVariables: []
+  description: Mycontainer JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -22,6 +23,7 @@
     builtin.hasTags:
     - Mycontainer JTA
 - customVariables: []
+  description: Geronimo JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -34,6 +36,7 @@
     builtin.hasTags:
     - Geronimo JTA
 - customVariables: []
+  description: OW2 JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -46,6 +49,7 @@
     builtin.hasTags:
     - OW2 JTA
 - customVariables: []
+  description: Evo JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -58,6 +62,7 @@
     builtin.hasTags:
     - Evo JTA
 - customVariables: []
+  description: AKKA JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -70,6 +75,7 @@
     builtin.hasTags:
     - AKKA JTA
 - customVariables: []
+  description: KumuluzEE JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -82,6 +88,7 @@
     builtin.hasTags:
     - KumuluzEE JTA
 - customVariables: []
+  description: Ignite JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -94,6 +101,7 @@
     builtin.hasTags:
     - Ignite JTA
 - customVariables: []
+  description: Nuxeo JTA/JCA
   labels:
   - konveyor.io/include=always
   links: []
@@ -106,6 +114,7 @@
     builtin.hasTags:
     - Nuxeo JTA/JCA
 - customVariables: []
+  description: Everit JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -118,6 +127,7 @@
     builtin.hasTags:
     - Everit JTA
 - customVariables: []
+  description: Demoiselle JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -130,6 +140,7 @@
     builtin.hasTags:
     - Demoiselle JTA
 - customVariables: []
+  description: Apache Meecrowave JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -142,6 +153,7 @@
     builtin.hasTags:
     - Apache Meecrowave JTA
 - customVariables: []
+  description: Apache Sirona JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -154,6 +166,7 @@
     builtin.hasTags:
     - Apache Sirona JTA
 - customVariables: []
+  description: Lift JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -166,6 +179,7 @@
     builtin.hasTags:
     - Lift JTA
 - customVariables: []
+  description: WF Core JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -178,6 +192,7 @@
     builtin.hasTags:
     - WF Core JTA
 - customVariables: []
+  description: Java Transaction API
   labels:
   - konveyor.io/include=always
   links: []
@@ -190,6 +205,7 @@
     builtin.hasTags:
     - Java Transaction API
 - customVariables: []
+  description: JBoss Transactions
   labels:
   - konveyor.io/include=always
   links: []
@@ -202,6 +218,7 @@
     builtin.hasTags:
     - JBoss Transactions
 - customVariables: []
+  description: GlassFish JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -214,6 +231,7 @@
     builtin.hasTags:
     - GlassFish JTA
 - customVariables: []
+  description: Atomikos JTA
   labels:
   - konveyor.io/include=always
   links: []
@@ -226,6 +244,7 @@
     builtin.hasTags:
     - Atomikos JTA
 - customVariables: []
+  description: Narayana Arjuna
   labels:
   - konveyor.io/include=always
   links: []
@@ -238,6 +257,7 @@
     builtin.hasTags:
     - Narayana Arjuna
 - customVariables: []
+  description: Spring Transactions
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/190-clustering.windup.yaml
+++ b/default/generated/technology-usage/190-clustering.windup.yaml
@@ -11,12 +11,15 @@
     url: https://learn.microsoft.com/azure/app-service/environment/app-service-app-service-environment-custom-settings
   - title: Identify session persistence mechanism
     url: https://learn.microsoft.com/azure/developer/java/migration/migrate-tomcat-to-azure-container-apps#identify-session-persistence-mechanism
-  message: |-
-    To migrate a distributed application that is clustered around several servers to Azure, you can follow these recommendations:
-
-     * **Configure multiple instances **: Deploy your Java application to Azure App Service and configure multiple instances within the same App Service Plan to create a cluster-like setup. Azure App Service automatically load-balances incoming requests across the available instances, ensuring scalability and high availability.
-
-     * **Manage sessions in a clustered environment**: Consider using an external session store such as Azure Cache for Redis. Configure your Java application to connect to the Azure Cache for Redis and to replicate sessions across the instances.
+  message: "To migrate a distributed application that is clustered around several\
+    \ servers to Azure, you can follow these recommendations:\n\n * **Configure multiple\
+    \ instances **: Deploy your Java application to Azure App Service and configure\
+    \ multiple instances within the same App Service Plan to create a cluster-like\
+    \ setup. Azure App Service automatically load-balances incoming requests across\
+    \ the available instances, ensuring scalability and high availability.\n\n * **Manage\
+    \ sessions in a clustered environment**: Consider using an external session store\
+    \ such as Azure Cache for Redis. Configure your Java application to connect to\
+    \ the Azure Cache for Redis and to replicate sessions across the instances."
   ruleID: clustering-00000
   tag:
   - Clustering Web Session
@@ -26,6 +29,7 @@
         w: http://java.sun.com/xml/ns/javaee
       xpath: /w:web-app/w:distributable
 - customVariables: []
+  description: Clustering EJB
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/20-javase-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/20-javase-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Java Threads
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/21-javaee-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/21-javaee-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Java EE Batch API
   labels:
   - konveyor.io/include=always
   links: []
@@ -10,9 +11,11 @@
       filepaths:
       - batch.xml
       namespaces:
-        "": http://xmlns.jcp.org/xml/ns/javaee
+        ? ''
+        : http://xmlns.jcp.org/xml/ns/javaee
       xpath: //*[local-name() = 'batch-artifacts']
 - customVariables: []
+  description: Java EE Batch
   labels:
   - konveyor.io/include=always
   links: []
@@ -29,9 +32,11 @@
         filepaths: '{{xmlfiles1.filepaths}}'
         from: xmlfiles1
         namespaces:
-          "": http://xmlns.jcp.org/xml/ns/javaee
+          ? ''
+          : http://xmlns.jcp.org/xml/ns/javaee
         xpath: //*[local-name() = 'job']
 - customVariables: []
+  description: Java EE Batch API
   labels:
   - konveyor.io/include=always
   links: []
@@ -44,6 +49,7 @@
     builtin.hasTags:
     - Java EE Batch API
 - customVariables: []
+  description: Java EE Batch
   labels:
   - konveyor.io/include=always
   links: []
@@ -56,6 +62,7 @@
     builtin.hasTags:
     - Java EE Batch
 - customVariables: []
+  description: CDI
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +78,7 @@
         location: PACKAGE
         pattern: javax.inject*
 - customVariables: []
+  description: CDI
   labels:
   - konveyor.io/include=always
   links: []
@@ -86,6 +94,7 @@
         location: PACKAGE
         pattern: jakarta.inject*
 - customVariables: []
+  description: CDI
   labels:
   - konveyor.io/include=always
   links: []
@@ -98,6 +107,7 @@
     builtin.hasTags:
     - CDI
 - customVariables: []
+  description: Java EE JSON-P
   labels:
   - konveyor.io/include=always
   links: []
@@ -109,6 +119,7 @@
       location: PACKAGE
       pattern: javax.json*
 - customVariables: []
+  description: Java EE JSON-P
   labels:
   - konveyor.io/include=always
   links: []
@@ -256,6 +267,7 @@
       location: IMPORT
       pattern: javax.json.bind*
 - customVariables: []
+  description: JACC
   labels:
   - konveyor.io/include=always
   links: []
@@ -268,6 +280,7 @@
     builtin.hasTags:
     - JACC
 - customVariables: []
+  description: MEJB
   labels:
   - konveyor.io/include=always
   links: []
@@ -280,6 +293,7 @@
     builtin.hasTags:
     - MEJB
 - customVariables: []
+  description: EAR
   labels:
   - konveyor.io/include=always
   links: []
@@ -292,6 +306,7 @@
     builtin.hasTags:
     - EAR
 - customVariables: []
+  description: WS Metadata
   labels:
   - konveyor.io/include=always
   links: []
@@ -304,6 +319,7 @@
     builtin.hasTags:
     - WS Metadata
 - customVariables: []
+  description: Common Annotations
   labels:
   - konveyor.io/include=always
   links: []
@@ -316,6 +332,7 @@
     builtin.hasTags:
     - Common Annotations
 - customVariables: []
+  description: JAXB
   labels:
   - konveyor.io/include=always
   links: []
@@ -328,6 +345,7 @@
     builtin.hasTags:
     - JAXB
 - customVariables: []
+  description: JAXR
   labels:
   - konveyor.io/include=always
   links: []
@@ -340,6 +358,7 @@
     builtin.hasTags:
     - JAXR
 - customVariables: []
+  description: Bean Validation
   labels:
   - konveyor.io/include=always
   links: []
@@ -352,6 +371,7 @@
     builtin.hasTags:
     - Bean Validation
 - customVariables: []
+  description: JSON-B
   labels:
   - konveyor.io/include=always
   links: []
@@ -364,6 +384,7 @@
     builtin.hasTags:
     - JSON-B
 - customVariables: []
+  description: Servlet
   labels:
   - konveyor.io/include=always
   links: []
@@ -376,6 +397,7 @@
     builtin.hasTags:
     - Servlet
 - customVariables: []
+  description: JPA Mapping XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -389,6 +411,7 @@
         p: http://xmlns.jcp.org/xml/ns/persistence/orm
       xpath: //p:entity-mappings/@version[matches(self::node(), '(1.0|2.0|2.1|2.2)')]
 - customVariables: []
+  description: JPA Mapping XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -402,6 +425,7 @@
         p: https://jakarta.ee/xml/ns/persistence/orm
       xpath: //p:entity-mappings/@version[matches(self::node(), '(3.0|3.1)')]
 - customVariables: []
+  description: CDI XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -415,6 +439,7 @@
         p: http://xmlns.jcp.org/xml/ns/javaee
       xpath: //p:beans/@version[matches(self::node(), '(1.0|1.1|2.0)')]
 - customVariables: []
+  description: CDI XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -428,6 +453,7 @@
         p: https://jakarta.ee/xml/ns/jakartaee
       xpath: //p:beans/@version[matches(self::node(), '(3.0|4.0)')]
 - customVariables: []
+  description: Java EE XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -441,6 +467,7 @@
         p: http://java.sun.com/xml/ns/javaee
       xpath: //p:application/@version[matches(self::node(), '(5|6)')]
 - customVariables: []
+  description: Java EE XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -454,6 +481,7 @@
         p: http://xmlns.jcp.org/xml/ns/javaee
       xpath: //p:application/@version[matches(self::node(), '(7|8)')]
 - customVariables: []
+  description: Jakarta EE XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -467,6 +495,7 @@
         p: https://jakarta.ee/xml/ns/jakartaee
       xpath: //p:application/@version[matches(self::node(), '(9|10)')]
 - customVariables: []
+  description: Java EE Client XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -480,6 +509,7 @@
         p: http://java.sun.com/xml/ns/javaee
       xpath: //p:application-client/@version[matches(self::node(), '(5|6)')]
 - customVariables: []
+  description: Java EE Client XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -493,6 +523,7 @@
         p: http://xmlns.jcp.org/xml/ns/javaee
       xpath: //p:application-client/@version[matches(self::node(), '(7|8)')]
 - customVariables: []
+  description: Jakarta EE Client XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -506,6 +537,7 @@
         p: https://jakarta.ee/xml/ns/jakartaee
       xpath: //p:application-client/@version[matches(self::node(), '(9|10)')]
 - customVariables: []
+  description: Connector XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -519,6 +551,7 @@
         p: http://java.sun.com/xml/ns/javaee
       xpath: //p:connector/@version[matches(self::node(), '(1.6)')]
 - customVariables: []
+  description: Connector XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -532,6 +565,7 @@
         p: http://xmlns.jcp.org/xml/ns/javaee
       xpath: //p:connector/@version[matches(self::node(), '(1.7)')]
 - customVariables: []
+  description: Connector XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -545,6 +579,7 @@
         p: https://jakarta.ee/xml/ns/jakartaee
       xpath: //p:connector/@version[matches(self::node(), '(2.0|2.1)')]
 - customVariables: []
+  description: JSF XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -558,6 +593,7 @@
         p: http://java.sun.com/xml/ns/javaee
       xpath: //p:faces-config/@version[matches(self::node(), '(1.2|2.0)')]
 - customVariables: []
+  description: JSF XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -571,6 +607,7 @@
         p: http://xmlns.jcp.org/xml/ns/javaee
       xpath: //p:faces-config/@version[matches(self::node(), '(2.2|2.3)')]
 - customVariables: []
+  description: JSF XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -584,6 +621,7 @@
         p: https://jakarta.ee/xml/ns/jakartaee
       xpath: //p:faces-config/@version[matches(self::node(), '(3.0|4.0)')]
 - customVariables: []
+  description: WebServices XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -597,6 +635,7 @@
         p: http://java.sun.com/xml/ns/javaee
       xpath: //p:webservices/@version[matches(self::node(), '(1.2|1.3)')]
 - customVariables: []
+  description: WebServices XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -610,6 +649,7 @@
         p: http://xmlns.jcp.org/xml/ns/javaee
       xpath: //p:webservices/@version[matches(self::node(), '(1.4)')]
 - customVariables: []
+  description: WebServices XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -623,6 +663,7 @@
         p: https://jakarta.ee/xml/ns/jakartaee
       xpath: //p:webservices/@version[matches(self::node(), '(2.0)')]
 - customVariables: []
+  description: JPA Mapping XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -635,6 +676,7 @@
     builtin.hasTags:
     - JPA Mapping XML
 - customVariables: []
+  description: CDI XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -647,6 +689,7 @@
     builtin.hasTags:
     - CDI XML
 - customVariables: []
+  description: Java EE XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -659,6 +702,7 @@
     builtin.hasTags:
     - Java EE XML
 - customVariables: []
+  description: Jakarta EE XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -671,6 +715,7 @@
     builtin.hasTags:
     - Jakarta EE XML
 - customVariables: []
+  description: Java EE Client XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -683,6 +728,7 @@
     builtin.hasTags:
     - Java EE Client XML
 - customVariables: []
+  description: Jakarta EE Client XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -695,6 +741,7 @@
     builtin.hasTags:
     - Jakarta EE Client XML
 - customVariables: []
+  description: Connector XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -707,6 +754,7 @@
     builtin.hasTags:
     - Connector XML
 - customVariables: []
+  description: JSF XML
   labels:
   - konveyor.io/include=always
   links: []
@@ -719,6 +767,7 @@
     builtin.hasTags:
     - JSF XML
 - customVariables: []
+  description: WebServices XML
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/23-integration-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/23-integration-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Apache Camel
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Apache Camel
 - customVariables: []
+  description: Teiid
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - Teiid
 - customVariables: []
+  description: Spring Integration
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Spring Integration
 - customVariables: []
+  description: Ikasan
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - Ikasan
 - customVariables: []
+  description: Swagger
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - Swagger
 - customVariables: []
+  description: Apiman
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - Apiman
 - customVariables: []
+  description: 3scale
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - 3scale
 - customVariables: []
+  description: Istio
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - Istio
 - customVariables: []
+  description: ServiceMix
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - ServiceMix
 - customVariables: []
+  description: Mule
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - Mule
 - customVariables: []
+  description: Petals EIP
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - Petals EIP
 - customVariables: []
+  description: SwitchYard
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - SwitchYard
 - customVariables: []
+  description: Apache Synapse
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - Apache Synapse
 - customVariables: []
+  description: WSO2
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - WSO2
 - customVariables: []
+  description: Talend ESB
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/26-embedded-framework-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/26-embedded-framework-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Apache Axis
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Apache Axis
 - customVariables: []
+  description: Apache Axis2
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - Apache Axis2
 - customVariables: []
+  description: Apache CXF
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Apache CXF
 - customVariables: []
+  description: XFire
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - XFire
 - customVariables: []
+  description: Jersey
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - Jersey
 - customVariables: []
+  description: Unirest
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - Unirest
 - customVariables: []
+  description: Hibernate
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - Hibernate
 - customVariables: []
+  description: Hibernate OGM
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - Hibernate OGM
 - customVariables: []
+  description: EclipseLink
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - EclipseLink
 - customVariables: []
+  description: Spring Batch
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - Spring Batch
 - customVariables: []
+  description: Spring
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - Spring
 - customVariables: []
+  description: AspectJ
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - AspectJ
 - customVariables: []
+  description: JBPM
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - JBPM
 - customVariables: []
+  description: iLog
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - iLog
 - customVariables: []
+  description: Ehcache
   labels:
   - konveyor.io/include=always
   links: []
@@ -179,6 +194,7 @@
     builtin.hasTags:
     - Ehcache
 - customVariables: []
+  description: Infinispan
   labels:
   - konveyor.io/include=always
   links: []
@@ -191,6 +207,7 @@
     builtin.hasTags:
     - Infinispan
 - customVariables: []
+  description: Drools
   labels:
   - konveyor.io/include=always
   links: []
@@ -203,6 +220,7 @@
     builtin.hasTags:
     - Drools
 - customVariables: []
+  description: Camunda
   labels:
   - konveyor.io/include=always
   links: []
@@ -215,6 +233,7 @@
     builtin.hasTags:
     - Camunda
 - customVariables: []
+  description: Pega
   labels:
   - konveyor.io/include=always
   links: []
@@ -227,6 +246,7 @@
     builtin.hasTags:
     - Pega
 - customVariables: []
+  description: Blaze
   labels:
   - konveyor.io/include=always
   links: []
@@ -239,6 +259,7 @@
     builtin.hasTags:
     - Blaze
 - customVariables: []
+  description: MRules
   labels:
   - konveyor.io/include=always
   links: []
@@ -251,6 +272,7 @@
     builtin.hasTags:
     - MRules
 - customVariables: []
+  description: Easy Rules
   labels:
   - konveyor.io/include=always
   links: []
@@ -263,6 +285,7 @@
     builtin.hasTags:
     - Easy Rules
 - customVariables: []
+  description: Coherence
   labels:
   - konveyor.io/include=always
   links: []
@@ -275,6 +298,7 @@
     builtin.hasTags:
     - Coherence
 - customVariables: []
+  description: Apache Commons JCS
   labels:
   - konveyor.io/include=always
   links: []
@@ -287,6 +311,7 @@
     builtin.hasTags:
     - Apache Commons JCS
 - customVariables: []
+  description: Dynacache
   labels:
   - konveyor.io/include=always
   links: []
@@ -299,6 +324,7 @@
     builtin.hasTags:
     - Dynacache
 - customVariables: []
+  description: Cache API
   labels:
   - konveyor.io/include=always
   links: []
@@ -311,6 +337,7 @@
     builtin.hasTags:
     - Cache API
 - customVariables: []
+  description: Hazelcast
   labels:
   - konveyor.io/include=always
   links: []
@@ -323,6 +350,7 @@
     builtin.hasTags:
     - Hazelcast
 - customVariables: []
+  description: Apache Ignite
   labels:
   - konveyor.io/include=always
   links: []
@@ -335,6 +363,7 @@
     builtin.hasTags:
     - Apache Ignite
 - customVariables: []
+  description: JBoss Cache
   labels:
   - konveyor.io/include=always
   links: []
@@ -347,6 +376,7 @@
     builtin.hasTags:
     - JBoss Cache
 - customVariables: []
+  description: JCache
   labels:
   - konveyor.io/include=always
   links: []
@@ -359,6 +389,7 @@
     builtin.hasTags:
     - JCache
 - customVariables: []
+  description: Memcached client
   labels:
   - konveyor.io/include=always
   links: []
@@ -371,6 +402,7 @@
     builtin.hasTags:
     - Memcached client
 - customVariables: []
+  description: Oscache
   labels:
   - konveyor.io/include=always
   links: []
@@ -383,6 +415,7 @@
     builtin.hasTags:
     - Oscache
 - customVariables: []
+  description: ShiftOne
   labels:
   - konveyor.io/include=always
   links: []
@@ -395,6 +428,7 @@
     builtin.hasTags:
     - ShiftOne
 - customVariables: []
+  description: SwarmCache
   labels:
   - konveyor.io/include=always
   links: []
@@ -407,6 +441,7 @@
     builtin.hasTags:
     - SwarmCache
 - customVariables: []
+  description: AOP Alliance
   labels:
   - konveyor.io/include=always
   links: []
@@ -419,6 +454,7 @@
     builtin.hasTags:
     - AOP Alliance
 - customVariables: []
+  description: SNMP4J
   labels:
   - konveyor.io/include=always
   links: []
@@ -431,6 +467,7 @@
     builtin.hasTags:
     - SNMP4J
 - customVariables: []
+  description: HTTP Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -443,6 +480,7 @@
     builtin.hasTags:
     - HTTP Client
 - customVariables: []
+  description: Javax Inject
   labels:
   - konveyor.io/include=always
   links: []
@@ -455,6 +493,7 @@
     builtin.hasTags:
     - Javax Inject
 - customVariables: []
+  description: Google Guice
   labels:
   - konveyor.io/include=always
   links: []
@@ -467,6 +506,7 @@
     builtin.hasTags:
     - Google Guice
 - customVariables: []
+  description: Plexus Container
   labels:
   - konveyor.io/include=always
   links: []
@@ -479,6 +519,7 @@
     builtin.hasTags:
     - Plexus Container
 - customVariables: []
+  description: Weld
   labels:
   - konveyor.io/include=always
   links: []
@@ -491,6 +532,7 @@
     builtin.hasTags:
     - Weld
 - customVariables: []
+  description: Dagger
   labels:
   - konveyor.io/include=always
   links: []
@@ -503,6 +545,7 @@
     builtin.hasTags:
     - Dagger
 - customVariables: []
+  description: GIN
   labels:
   - konveyor.io/include=always
   links: []
@@ -515,6 +558,7 @@
     builtin.hasTags:
     - GIN
 - customVariables: []
+  description: PicoContainer
   labels:
   - konveyor.io/include=always
   links: []
@@ -527,6 +571,7 @@
     builtin.hasTags:
     - PicoContainer
 - customVariables: []
+  description: Scaldi
   labels:
   - konveyor.io/include=always
   links: []
@@ -539,6 +584,7 @@
     builtin.hasTags:
     - Scaldi
 - customVariables: []
+  description: Macros
   labels:
   - konveyor.io/include=always
   links: []
@@ -551,6 +597,7 @@
     builtin.hasTags:
     - Macros
 - customVariables: []
+  description: Injekt for Kotlin
   labels:
   - konveyor.io/include=always
   links: []
@@ -563,6 +610,7 @@
     builtin.hasTags:
     - Injekt for Kotlin
 - customVariables: []
+  description: Kodein
   labels:
   - konveyor.io/include=always
   links: []
@@ -575,6 +623,7 @@
     builtin.hasTags:
     - Kodein
 - customVariables: []
+  description: Peaberry
   labels:
   - konveyor.io/include=always
   links: []
@@ -587,6 +636,7 @@
     builtin.hasTags:
     - Peaberry
 - customVariables: []
+  description: Sticky Configured
   labels:
   - konveyor.io/include=always
   links: []
@@ -599,6 +649,7 @@
     builtin.hasTags:
     - Sticky Configured
 - customVariables: []
+  description: Ka DI
   labels:
   - konveyor.io/include=always
   links: []
@@ -611,6 +662,7 @@
     builtin.hasTags:
     - Ka DI
 - customVariables: []
+  description: Polyforms DI
   labels:
   - konveyor.io/include=always
   links: []
@@ -623,6 +675,7 @@
     builtin.hasTags:
     - Polyforms DI
 - customVariables: []
+  description: JayWire
   labels:
   - konveyor.io/include=always
   links: []
@@ -635,6 +688,7 @@
     builtin.hasTags:
     - JayWire
 - customVariables: []
+  description: Silk DI
   labels:
   - konveyor.io/include=always
   links: []
@@ -647,6 +701,7 @@
     builtin.hasTags:
     - Silk DI
 - customVariables: []
+  description: Grapht DI
   labels:
   - konveyor.io/include=always
   links: []
@@ -659,6 +714,7 @@
     builtin.hasTags:
     - Grapht DI
 - customVariables: []
+  description: Syringe
   labels:
   - konveyor.io/include=always
   links: []
@@ -671,6 +727,7 @@
     builtin.hasTags:
     - Syringe
 - customVariables: []
+  description: Cfg Engine
   labels:
   - konveyor.io/include=always
   links: []
@@ -683,6 +740,7 @@
     builtin.hasTags:
     - Cfg Engine
 - customVariables: []
+  description: BeanInject
   labels:
   - konveyor.io/include=always
   links: []
@@ -695,6 +753,7 @@
     builtin.hasTags:
     - BeanInject
 - customVariables: []
+  description: Tornado Inject
   labels:
   - konveyor.io/include=always
   links: []
@@ -707,6 +766,7 @@
     builtin.hasTags:
     - Tornado Inject
 - customVariables: []
+  description: Airframe
   labels:
   - konveyor.io/include=always
   links: []
@@ -719,6 +779,7 @@
     builtin.hasTags:
     - Airframe
 - customVariables: []
+  description: Winter
   labels:
   - konveyor.io/include=always
   links: []
@@ -731,6 +792,7 @@
     builtin.hasTags:
     - Winter
 - customVariables: []
+  description: KouInject
   labels:
   - konveyor.io/include=always
   links: []
@@ -743,6 +805,7 @@
     builtin.hasTags:
     - KouInject
 - customVariables: []
+  description: Iroh
   labels:
   - konveyor.io/include=always
   links: []
@@ -755,6 +818,7 @@
     builtin.hasTags:
     - Iroh
 - customVariables: []
+  description: Micro DI
   labels:
   - konveyor.io/include=always
   links: []
@@ -767,6 +831,7 @@
     builtin.hasTags:
     - Micro DI
 - customVariables: []
+  description: SubCut
   labels:
   - konveyor.io/include=always
   links: []
@@ -779,6 +844,7 @@
     builtin.hasTags:
     - SubCut
 - customVariables: []
+  description: Spring DI
   labels:
   - konveyor.io/include=always
   links: []
@@ -791,6 +857,7 @@
     builtin.hasTags:
     - Spring DI
 - customVariables: []
+  description: Micrometer
   labels:
   - konveyor.io/include=always
   links: []
@@ -803,6 +870,7 @@
     builtin.hasTags:
     - Micrometer
 - customVariables: []
+  description: Spring Web
   labels:
   - konveyor.io/include=always
   links: []
@@ -815,6 +883,7 @@
     builtin.hasTags:
     - Spring Web
 - customVariables: []
+  description: Spring Boot Cache
   labels:
   - konveyor.io/include=always
   links: []
@@ -827,6 +896,7 @@
     builtin.hasTags:
     - Spring Boot Cache
 - customVariables: []
+  description: Spring Shell
   labels:
   - konveyor.io/include=always
   links: []
@@ -839,6 +909,7 @@
     builtin.hasTags:
     - Spring Shell
 - customVariables: []
+  description: Spring Scheduled
   labels:
   - konveyor.io/include=always
   links: []
@@ -851,6 +922,7 @@
     builtin.hasTags:
     - Spring Scheduled
 - customVariables: []
+  description: Spring Cloud Function
   labels:
   - konveyor.io/include=always
   links: []
@@ -863,6 +935,7 @@
     builtin.hasTags:
     - Spring Cloud Function
 - customVariables: []
+  description: Quartz
   labels:
   - konveyor.io/include=always
   links: []
@@ -875,6 +948,7 @@
     builtin.hasTags:
     - Quartz
 - customVariables: []
+  description: Feign
   labels:
   - konveyor.io/include=always
   links: []
@@ -887,6 +961,7 @@
     builtin.hasTags:
     - Feign
 - customVariables: []
+  description: Zipkin
   labels:
   - konveyor.io/include=always
   links: []
@@ -899,6 +974,7 @@
     builtin.hasTags:
     - Zipkin
 - customVariables: []
+  description: Redis
   labels:
   - konveyor.io/include=always
   links: []
@@ -911,6 +987,7 @@
     builtin.hasTags:
     - Redis
 - customVariables: []
+  description: Eureka
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/28-ejb-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/28-ejb-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: EJB Timer
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/31-database-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/31-database-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: HSQLDB Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - HSQLDB Driver
 - customVariables: []
+  description: MySQL Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - MySQL Driver
 - customVariables: []
+  description: Derby Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Derby Driver
 - customVariables: []
+  description: PostgreSQL Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - PostgreSQL Driver
 - customVariables: []
+  description: H2 Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - H2 Driver
 - customVariables: []
+  description: Microsoft SQL Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - Microsoft SQL Driver
 - customVariables: []
+  description: SQLite Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - SQLite Driver
 - customVariables: []
+  description: Oracle DB Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - Oracle DB Driver
 - customVariables: []
+  description: Cassandra Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - Cassandra Client
 - customVariables: []
+  description: Axion Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - Axion Driver
 - customVariables: []
+  description: MckoiSQLDB Driver
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - MckoiSQLDB Driver
 - customVariables: []
+  description: MongoDB Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - MongoDB Client
 - customVariables: []
+  description: Spring Data
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - Spring Data
 - customVariables: []
+  description: Morphia
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - Morphia
 - customVariables: []
+  description: LevelDB Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -179,6 +194,7 @@
     builtin.hasTags:
     - LevelDB Client
 - customVariables: []
+  description: Apache HBase Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -191,6 +207,7 @@
     builtin.hasTags:
     - Apache HBase Client
 - customVariables: []
+  description: Apache Accumulo Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -203,6 +220,7 @@
     builtin.hasTags:
     - Apache Accumulo Client
 - customVariables: []
+  description: Spring Data JPA
   labels:
   - konveyor.io/include=always
   links: []
@@ -215,6 +233,7 @@
     builtin.hasTags:
     - Spring Data JPA
 - customVariables: []
+  description: MariaDB Driver
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/33-connect-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/33-connect-technology-usage.windup.yaml
@@ -105,6 +105,7 @@
     - builtin.file:
         pattern: ra\.xml
 - customVariables: []
+  description: Resource Adapter
   labels:
   - konveyor.io/include=always
   links: []
@@ -117,6 +118,7 @@
     builtin.hasTags:
     - Resource Adapter
 - customVariables: []
+  description: ActiveMQ
   labels:
   - konveyor.io/include=always
   links: []
@@ -129,6 +131,7 @@
     builtin.hasTags:
     - ActiveMQ
 - customVariables: []
+  description: OpenWS
   labels:
   - konveyor.io/include=always
   links: []
@@ -141,6 +144,7 @@
     builtin.hasTags:
     - OpenWS
 - customVariables: []
+  description: WSDL
   labels:
   - konveyor.io/include=always
   links: []
@@ -153,6 +157,7 @@
     builtin.hasTags:
     - WSDL
 - customVariables: []
+  description: RabbitMQ Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -165,6 +170,7 @@
     builtin.hasTags:
     - RabbitMQ Client
 - customVariables: []
+  description: Spring Messaging Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -177,6 +183,7 @@
     builtin.hasTags:
     - Spring Messaging Client
 - customVariables: []
+  description: Camel Messaging Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -189,6 +196,7 @@
     builtin.hasTags:
     - Camel Messaging Client
 - customVariables: []
+  description: Amazon SQS Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -201,6 +209,7 @@
     builtin.hasTags:
     - Amazon SQS Client
 - customVariables: []
+  description: HornetQ Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -213,6 +222,7 @@
     builtin.hasTags:
     - HornetQ Client
 - customVariables: []
+  description: AMQP Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -225,6 +235,7 @@
     builtin.hasTags:
     - AMQP Client
 - customVariables: []
+  description: RocketMQ Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -237,6 +248,7 @@
     builtin.hasTags:
     - RocketMQ Client
 - customVariables: []
+  description: 0MQ Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -249,6 +261,7 @@
     builtin.hasTags:
     - 0MQ Client
 - customVariables: []
+  description: JBossMQ Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -261,6 +274,7 @@
     builtin.hasTags:
     - JBossMQ Client
 - customVariables: []
+  description: Zbus Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -273,6 +287,7 @@
     builtin.hasTags:
     - Zbus Client
 - customVariables: []
+  description: Qpid Client
   labels:
   - konveyor.io/include=always
   links: []
@@ -285,6 +300,7 @@
     builtin.hasTags:
     - Qpid Client
 - customVariables: []
+  description: Kafka Client
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/35-configuration-management-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/35-configuration-management-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Spring Cloud Config
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Spring Cloud Config
 - customVariables: []
+  description: Application Properties File
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - Application Properties File
 - customVariables: []
+  description: Spring Properties
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Spring Properties
 - customVariables: []
+  description: Spring Cloud Vault
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/37-clustering-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/37-clustering-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Clustering Web Session
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Clustering Web Session
 - customVariables: []
+  description: Clustering EJB
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/39-3rd-party-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/39-3rd-party-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Liferay
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Liferay
 - customVariables: []
+  description: Oracle Forms
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - Oracle Forms
 - customVariables: []
+  description: Spring Boot
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Spring Boot
 - customVariables: []
+  description: Elasticsearch
   labels:
   - konveyor.io/include=always
   links: []
@@ -47,6 +51,7 @@
     builtin.hasTags:
     - Elasticsearch
 - customVariables: []
+  description: Logstash
   labels:
   - konveyor.io/include=always
   links: []
@@ -59,6 +64,7 @@
     builtin.hasTags:
     - Logstash
 - customVariables: []
+  description: Jetty
   labels:
   - konveyor.io/include=always
   links: []
@@ -71,6 +77,7 @@
     builtin.hasTags:
     - Jetty
 - customVariables: []
+  description: Tomcat
   labels:
   - konveyor.io/include=always
   links: []
@@ -83,6 +90,7 @@
     builtin.hasTags:
     - Tomcat
 - customVariables: []
+  description: Kibana
   labels:
   - konveyor.io/include=always
   links: []
@@ -95,6 +103,7 @@
     builtin.hasTags:
     - Kibana
 - customVariables: []
+  description: Apache Karaf
   labels:
   - konveyor.io/include=always
   links: []
@@ -107,6 +116,7 @@
     builtin.hasTags:
     - Apache Karaf
 - customVariables: []
+  description: Neo4j
   labels:
   - konveyor.io/include=always
   links: []
@@ -119,6 +129,7 @@
     builtin.hasTags:
     - Neo4j
 - customVariables: []
+  description: Spark
   labels:
   - konveyor.io/include=always
   links: []
@@ -131,6 +142,7 @@
     builtin.hasTags:
     - Spark
 - customVariables: []
+  description: Apache Hadoop
   labels:
   - konveyor.io/include=always
   links: []
@@ -143,6 +155,7 @@
     builtin.hasTags:
     - Apache Hadoop
 - customVariables: []
+  description: Apache Geronimo
   labels:
   - konveyor.io/include=always
   links: []
@@ -155,6 +168,7 @@
     builtin.hasTags:
     - Apache Geronimo
 - customVariables: []
+  description: Apache Aries
   labels:
   - konveyor.io/include=always
   links: []
@@ -167,6 +181,7 @@
     builtin.hasTags:
     - Apache Aries
 - customVariables: []
+  description: Cloudera
   labels:
   - konveyor.io/include=always
   links: []
@@ -179,6 +194,7 @@
     builtin.hasTags:
     - Cloudera
 - customVariables: []
+  description: MapR
   labels:
   - konveyor.io/include=always
   links: []
@@ -191,6 +207,7 @@
     builtin.hasTags:
     - MapR
 - customVariables: []
+  description: TensorFlow
   labels:
   - konveyor.io/include=always
   links: []
@@ -203,6 +220,7 @@
     builtin.hasTags:
     - TensorFlow
 - customVariables: []
+  description: Weka
   labels:
   - konveyor.io/include=always
   links: []
@@ -215,6 +233,7 @@
     builtin.hasTags:
     - Weka
 - customVariables: []
+  description: Apache Mahout
   labels:
   - konveyor.io/include=always
   links: []
@@ -227,6 +246,7 @@
     builtin.hasTags:
     - Apache Mahout
 - customVariables: []
+  description: Splunk
   labels:
   - konveyor.io/include=always
   links: []

--- a/default/generated/technology-usage/39-apm-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/39-apm-technology-usage.windup.yaml
@@ -1,4 +1,5 @@
 - customVariables: []
+  description: Application Insights
   labels:
   - konveyor.io/include=always
   links: []
@@ -11,6 +12,7 @@
     builtin.hasTags:
     - Application Insights
 - customVariables: []
+  description: New Relic
   labels:
   - konveyor.io/include=always
   links: []
@@ -23,6 +25,7 @@
     builtin.hasTags:
     - New Relic
 - customVariables: []
+  description: Elastic APM
   labels:
   - konveyor.io/include=always
   links: []
@@ -35,6 +38,7 @@
     builtin.hasTags:
     - Elastic APM
 - customVariables: []
+  description: Dynatrace
   labels:
   - konveyor.io/include=always
   links: []

--- a/util/check_descriptions.py
+++ b/util/check_descriptions.py
@@ -1,0 +1,107 @@
+"""
+This script takes directory with yaml rulesets and checks if there are rules without/with emtpy description field.
+
+Usage:
+   check_descriptions.py -d <rules_dir> [-o <output_dir>] [-r] [-w]
+
+Options:
+   -h --help                     Show this screen.
+   -d, --directory=<rules_dir>   Directory with the rulesets.
+   -w, --overwrite               Overwrite the original rulesets.
+   -o, --output=<output_dir>     Directory to save the new rulesets if -w is not set.
+   -r, --recursive               Recursively check all subdirectories.
+"""
+
+from pathlib import Path
+import yaml
+import docopt
+
+
+def analyze(directory, overwrite=False, recursive=False, output_dir=None):
+   checked_cnt = 0
+   missing_cnt = 0
+   rel_output_dir = Path(output_dir) / Path(directory).relative_to(Path(directory).anchor) if output_dir else None
+
+   print("#######################################################################")
+   print("Analyzing %s" % directory)
+   print("Output directory: %s" % (rel_output_dir if rel_output_dir else "None"))
+   print
+
+   if rel_output_dir:
+      Path(rel_output_dir).mkdir(parents=True, exist_ok=True, mode=0o755)
+
+   rulesets_output = {}
+   for f in directory.iterdir():
+      if f.is_file() and f.suffix == '.yaml' and not f.name.endswith('ruleset.yaml'):
+         rulesets_output[f] = None
+         if overwrite:
+            rulesets_output[f] = f
+         elif rel_output_dir:
+            rulesets_output[f] = rel_output_dir / f.name
+
+   for ruleset, ruleset_out in rulesets_output.items():
+      rules = {}
+      ruleset_missing_cnt = 0
+      updated_ruleset = False
+
+      with open(ruleset) as data:
+         try:
+            rules = yaml.safe_load(data)
+            for rule in rules:
+               checked_cnt += 1
+               if rule.get("description") == None or rule["description"] == "":
+                  ruleset_missing_cnt += 1
+                  print("  " + rule["ruleID"])
+                  # Guess based on when condition
+                  if rule.get("when"):
+                     tags = rule.get("when").get("builtin.hasTags")   # Guess by Condition Tag
+                     if tags and len(tags) == 1:
+                        print("    description might be: %s" % tags[0])
+                        rule['description'] = tags[0]
+                        updated_ruleset = True
+                     else:
+                        tag = rule.get("tag")  # Guess by (given) Tag
+                        if tag and len(tag) == 1:
+                           print("    description might be: %s" % tag[0])
+                           rule['description'] = tag[0]
+                           updated_ruleset = True
+
+         except Exception as exc:
+            print("  Error reading %s: %s" % (f, exc))
+
+      if ruleset_out:
+         if ruleset_missing_cnt > 0 and updated_ruleset:
+            with open(ruleset_out, 'w') as rulesfile:
+               print("  Saving updated ruleset to %s" % ruleset_out)
+               yaml.dump(rules, rulesfile)
+         elif not overwrite:
+            with open(ruleset_out, 'w') as rulesfile:
+               with open(ruleset, "r", encoding="utf-8") as data:
+                  rulesfile.write(data.read())
+
+      missing_cnt += ruleset_missing_cnt
+
+   if recursive:
+      for d in Path(directory).iterdir():
+         if d.is_dir():
+            checked, missing = analyze(d, overwrite, recursive, output_dir)
+            checked_cnt += checked
+            missing_cnt += missing
+
+   return checked_cnt, missing_cnt
+
+
+args = docopt.docopt(__doc__)
+
+directory = args['--directory']
+output_dir = args['--output']
+recursive = args['--recursive']
+overwrite = args['--overwrite']
+
+if not Path(directory).is_dir():
+   print("Directory not found: %s" % directory)
+   exit(1)
+
+
+checked, missing = analyze(Path(directory), overwrite, recursive, Path(output_dir) if output_dir else None)
+print("Checked %d rules, %d missing descriptions" % (checked, missing))

--- a/util/requirements.txt
+++ b/util/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+docopt


### PR DESCRIPTION
Adding descriptions to rules without it.

Also, adding script to check all directories and subdirectories for missing descriptions. Based on upstream script logic: https://github.com/konveyor/rulesets/pull/159/files#diff-8b72ffcb02df3cf5fcdbd1c898d4dec36a757a6f098d6fec8a5c79c155b859a7