### PR TITLE
fix inconsistent rule between AppCAT 6.X and AppCAT 7.X

### DIFF
--- a/default/generated/azure/33-azure-message-queue.windup.yaml
+++ b/default/generated/azure/33-azure-message-queue.windup.yaml
@@ -230,6 +230,9 @@
     - java.dependency:
         lowerbound: 0.0.0
         name: org.springframework.boot.spring-boot-starter-amqp
+    - java.dependency:
+        lowerbound: 0.0.0
+        name: org.springframework.amqp.spring-rabbit
     - builtin.filecontent:
         filePattern: build\.gradle
         pattern: spring-boot-starter-amqp


### PR DESCRIPTION
In the AppCAT 6.X rules, there are two dependencies matching conditions for this rule.
But now, in AppCAT 7.X, there is only one dependency matching condition for this rule.
So fill the missing one.

![image](https://github.com/user-attachments/assets/434eef92-8849-4915-9989-8b1b61a0087c)
