### PR TITLE
Update rules description and regex

### DIFF
--- a/default/generated/azure/01-azure-aws-config.windup.yaml
+++ b/default/generated/azure/01-azure-aws-config.windup.yaml
@@ -112,6 +112,7 @@
         name: io.awspring.cloud.spring-cloud-aws-starter-s3
     - builtin.filecontent:
         filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
+        # currently no support multi-lines regex matching for yaml, so only match "s3:"
         pattern: (aws.s3|s3:\s*)
     - java.referenced:
         location: PACKAGE

--- a/default/generated/azure/01-azure-aws-config.windup.yaml
+++ b/default/generated/azure/01-azure-aws-config.windup.yaml
@@ -111,8 +111,8 @@
         lowerbound: 0.0.0
         name: io.awspring.cloud.spring-cloud-aws-starter-s3
     - builtin.filecontent:
-        filePattern: (application|bootstrap).*\.(properties|yaml|yml)
-        pattern: aws(?:\s*:\s*\n(?:\s+.+\n)*?\s*s3:|\.s3)
+        filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
+        pattern: (aws.s3|s3:\s*)
     - java.referenced:
         location: PACKAGE
         pattern: com.amazonaws.services.s3*
@@ -341,8 +341,8 @@
   ruleID: azure-aws-config-sqs-04004
   when:
     builtin.filecontent:
-      filePattern: (application|bootstrap).*\.(properties|yaml|yml)
-      pattern: aws(?:\s*:\s*\n(?:\s+.+\n)*?\s*sqs:|\.sqs)
+      filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
+      pattern: (aws.sqs|sqs:\s*)
 - category: mandatory
   customVariables: []
   description: AWS Secrets Manager configuration

--- a/default/generated/azure/02-azure-cache.windup.yaml
+++ b/default/generated/azure/02-azure-cache.windup.yaml
@@ -44,5 +44,5 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: (application|bootstrap).*\.(properties|yaml|yml)
+        filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
         pattern: (redis|jedis|lettuce)\.(.*\.)?(url|host|nodes|username|password)

--- a/default/generated/azure/03-azure-database-config.windup.yaml
+++ b/default/generated/azure/03-azure-database-config.windup.yaml
@@ -54,34 +54,34 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: 'jdbc:'
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.url
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.u-r-l
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.jdbc-url
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.username
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.user
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.password
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: jdbc.url
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: jdbc.username
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: jdbc.password
 - category: potential
   customVariables: []
@@ -124,16 +124,16 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: 'mongodb:'
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: mongodb.uri
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: mongodb.username
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: mongodb.password
 - category: potential
   customVariables: []
@@ -178,14 +178,14 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: 'r2dbc:'
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: r2dbc.username
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: r2dbc.password
     - builtin.filecontent:
-        filePattern: .*\.(xml|properties|yaml|yml)
+        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
         pattern: r2dbc.url

--- a/default/generated/azure/03-azure-database-config.windup.yaml
+++ b/default/generated/azure/03-azure-database-config.windup.yaml
@@ -54,34 +54,34 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: 'jdbc:'
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.url
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.u-r-l
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.jdbc-url
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.username
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.user
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: datasource.password
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: jdbc.url
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: jdbc.username
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: jdbc.password
 - category: potential
   customVariables: []
@@ -124,16 +124,16 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: 'mongodb:'
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: mongodb.uri
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: mongodb.username
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: mongodb.password
 - category: potential
   customVariables: []
@@ -178,14 +178,14 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: 'r2dbc:'
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: r2dbc.username
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: r2dbc.password
     - builtin.filecontent:
-        filePattern: (/|\\)([^/\\]+)\.(xml|properties|yaml|yml)$
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(xml|properties|yaml|yml)$
         pattern: r2dbc.url

--- a/default/generated/azure/04-azure-file-system.windup.yaml
+++ b/default/generated/azure/04-azure-file-system.windup.yaml
@@ -44,7 +44,7 @@
   ruleID: azure-file-system-02000
   when:
     builtin.filecontent:
-      filePattern: (/|\\)([^/\\]+)\.(java|properties|yaml|yml|xml)$
+      filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(java|properties|yaml|yml|xml)$
       pattern: \.\/.
 - category: optional
   customVariables: []
@@ -92,5 +92,5 @@
   ruleID: azure-file-system-03000
   when:
     builtin.filecontent:
-      filePattern: (/|\\)([^/\\]+)\.(java|properties|yaml|yml|xml)$
+      filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(java|properties|yaml|yml|xml)$
       pattern: \/home

--- a/default/generated/azure/04-azure-file-system.windup.yaml
+++ b/default/generated/azure/04-azure-file-system.windup.yaml
@@ -44,7 +44,7 @@
   ruleID: azure-file-system-02000
   when:
     builtin.filecontent:
-      filePattern: .*\.(java|properties|yaml|yml|xml)
+      filePattern: (/|\\)([^/\\]+)\.(java|properties|yaml|yml|xml)$
       pattern: \.\/.
 - category: optional
   customVariables: []
@@ -92,5 +92,5 @@
   ruleID: azure-file-system-03000
   when:
     builtin.filecontent:
-      filePattern: .*\.(java|properties|yaml|yml)
+      filePattern: (/|\\)([^/\\]+)\.(java|properties|yaml|yml|xml)$
       pattern: \/home

--- a/default/generated/azure/06-azure-keystore-certificates.windup.yaml
+++ b/default/generated/azure/06-azure-keystore-certificates.windup.yaml
@@ -40,7 +40,7 @@
   ruleID: azure-keystore-certificates-01000
   when:
     builtin.file:
-      pattern: ([^/\\]+)\.jks$
+      pattern: ([a-zA-Z0-9._-]+)\.jks$
 - category: potential
   customVariables: []
   description: The application loads certificates into a KeyStore

--- a/default/generated/azure/06-azure-keystore-certificates.windup.yaml
+++ b/default/generated/azure/06-azure-keystore-certificates.windup.yaml
@@ -40,7 +40,7 @@
   ruleID: azure-keystore-certificates-01000
   when:
     builtin.file:
-      pattern: ([a-zA-Z0-9._-]+)\.jks$
+      pattern: ^([a-zA-Z0-9._-]+)\.jks$
 - category: potential
   customVariables: []
   description: The application loads certificates into a KeyStore

--- a/default/generated/azure/06-azure-keystore-certificates.windup.yaml
+++ b/default/generated/azure/06-azure-keystore-certificates.windup.yaml
@@ -40,7 +40,7 @@
   ruleID: azure-keystore-certificates-01000
   when:
     builtin.file:
-      pattern: .*\.jks
+      pattern: ([^/\\]+)\.jks$
 - category: potential
   customVariables: []
   description: The application loads certificates into a KeyStore

--- a/default/generated/azure/07-azure-message-queue.windup.yaml
+++ b/default/generated/azure/07-azure-message-queue.windup.yaml
@@ -234,7 +234,7 @@
         lowerbound: 0.0.0
         name: org.springframework.amqp.spring-rabbit
     - builtin.filecontent:
-        filePattern: build\.gradle
+        filePattern: ^build\.gradle$
         pattern: spring-boot-starter-amqp
     - builtin.file:
         pattern: .*amqp.*

--- a/default/generated/azure/07-azure-message-queue.windup.yaml
+++ b/default/generated/azure/07-azure-message-queue.windup.yaml
@@ -52,7 +52,7 @@
   - Kafka Client
   when:
     builtin.filecontent:
-      filePattern: .*\.(properties|yaml|yml)
+      filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
       pattern: kafka\.(.*\.)?(properties\.)?(bootstrap[\.-]servers|sasl\.jaas\.config|schema\.registry)
 - category: optional
   customVariables: []
@@ -93,7 +93,7 @@
   - RabbitMQ Client
   when:
     builtin.filecontent:
-      filePattern: .*\.(properties|yaml|yml)
+      filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
       pattern: rabbitmq\.(.*\.)?(addresses|host|virtual-host|username|password)
 - category: optional
   customVariables: []
@@ -131,7 +131,7 @@
   - ActiveMQ
   when:
     builtin.filecontent:
-      filePattern: .*\.(properties|yaml|yml)
+      filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
       pattern: artemis\.(broker-url|user|password)
 - category: optional
   customVariables: []
@@ -339,5 +339,5 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: .*\.(properties|yaml|yml)
+        filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
         pattern: spring.cloud.azure.servicebus.*

--- a/default/generated/azure/07-azure-message-queue.windup.yaml
+++ b/default/generated/azure/07-azure-message-queue.windup.yaml
@@ -234,7 +234,7 @@
         lowerbound: 0.0.0
         name: org.springframework.amqp.spring-rabbit
     - builtin.filecontent:
-        filePattern: ^build\.gradle$
+        filePattern: (/|\\)build\.gradle$
         pattern: spring-boot-starter-amqp
     - builtin.file:
         pattern: .*amqp.*

--- a/default/generated/azure/08-azure-password.windup.yaml
+++ b/default/generated/azure/08-azure-password.windup.yaml
@@ -33,7 +33,7 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: application.*\.(properties|yaml|yml)
+        filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
         pattern: (password|pwd)
     - builtin.xml:
         namespaces: {}

--- a/default/generated/azure/09-azure-static-content.windup.yaml
+++ b/default/generated/azure/09-azure-static-content.windup.yaml
@@ -50,4 +50,4 @@
   ruleID: azure-static-content-01000
   when:
     builtin.file:
-      pattern: ([^/\\]+)\.(htm|html)$
+      pattern: ([a-zA-Z0-9._-]+)\.(htm|html)$

--- a/default/generated/azure/09-azure-static-content.windup.yaml
+++ b/default/generated/azure/09-azure-static-content.windup.yaml
@@ -50,4 +50,4 @@
   ruleID: azure-static-content-01000
   when:
     builtin.file:
-      pattern: .*\.(htm|html)
+      pattern: ([^/\\]+)\.(htm|html)$

--- a/default/generated/azure/09-azure-static-content.windup.yaml
+++ b/default/generated/azure/09-azure-static-content.windup.yaml
@@ -50,4 +50,4 @@
   ruleID: azure-static-content-01000
   when:
     builtin.file:
-      pattern: ([a-zA-Z0-9._-]+)\.(htm|html)$
+      pattern: ^([a-zA-Z0-9._-]+)\.(htm|html)$

--- a/default/generated/azure/11-azure-tas-binding.windup.yaml
+++ b/default/generated/azure/11-azure-tas-binding.windup.yaml
@@ -43,5 +43,5 @@
   ruleID: azure-tas-binding-01000
   when:
     builtin.filecontent:
-      filePattern: .*
+      filePattern: ""
       pattern: \W(VCAP_SERVICES)\W

--- a/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
+++ b/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
@@ -30,7 +30,7 @@
     or:
     - as: xmlfiles1
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles1.filepaths}}'
@@ -39,7 +39,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:db2')]
     - as: xmlfiles2
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles2.filepaths}}'
@@ -48,7 +48,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'db2')]
     - as: xmlfiles3
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles3.filepaths}}'
@@ -57,7 +57,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:mysql')]
     - as: xmlfiles4
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles4.filepaths}}'
@@ -66,7 +66,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'mysql')]
     - as: xmlfiles5
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles5.filepaths}}'
@@ -75,7 +75,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:oracle')]
     - as: xmlfiles6
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles6.filepaths}}'
@@ -84,7 +84,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'oracle')]
     - as: xmlfiles7
       builtin.file:
-        pattern: [^/\\]+)-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles7.filepaths}}'
@@ -93,7 +93,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:postgres')]
     - as: xmlfiles8
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles8.filepaths}}'
@@ -102,7 +102,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'postgres')]
     - as: xmlfiles9
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles9.filepaths}}'
@@ -111,7 +111,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:microsoft:sqlserver')]
     - as: xmlfiles10
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles10.filepaths}}'
@@ -120,7 +120,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'sqlserver')]
     - as: xmlfiles11
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles11.filepaths}}'
@@ -129,7 +129,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:sybase')]
     - as: xmlfiles12
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles12.filepaths}}'

--- a/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
+++ b/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
@@ -30,7 +30,7 @@
     or:
     - as: xmlfiles1
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles1.filepaths}}'
@@ -39,7 +39,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:db2')]
     - as: xmlfiles2
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles2.filepaths}}'
@@ -48,7 +48,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'db2')]
     - as: xmlfiles3
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles3.filepaths}}'
@@ -57,7 +57,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:mysql')]
     - as: xmlfiles4
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles4.filepaths}}'
@@ -66,7 +66,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'mysql')]
     - as: xmlfiles5
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles5.filepaths}}'
@@ -75,7 +75,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:oracle')]
     - as: xmlfiles6
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles6.filepaths}}'
@@ -84,7 +84,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'oracle')]
     - as: xmlfiles7
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles7.filepaths}}'
@@ -93,7 +93,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:postgres')]
     - as: xmlfiles8
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles8.filepaths}}'
@@ -102,7 +102,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'postgres')]
     - as: xmlfiles9
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles9.filepaths}}'
@@ -111,7 +111,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:microsoft:sqlserver')]
     - as: xmlfiles10
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles10.filepaths}}'
@@ -120,7 +120,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'sqlserver')]
     - as: xmlfiles11
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles11.filepaths}}'
@@ -129,7 +129,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:sybase')]
     - as: xmlfiles12
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles12.filepaths}}'

--- a/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
+++ b/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
@@ -30,7 +30,7 @@
     or:
     - as: xmlfiles1
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles1.filepaths}}'
@@ -39,7 +39,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:db2')]
     - as: xmlfiles2
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles2.filepaths}}'
@@ -48,7 +48,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'db2')]
     - as: xmlfiles3
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles3.filepaths}}'
@@ -57,7 +57,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:mysql')]
     - as: xmlfiles4
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles4.filepaths}}'
@@ -66,7 +66,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'mysql')]
     - as: xmlfiles5
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles5.filepaths}}'
@@ -75,7 +75,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:oracle')]
     - as: xmlfiles6
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles6.filepaths}}'
@@ -84,7 +84,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'oracle')]
     - as: xmlfiles7
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: [^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles7.filepaths}}'
@@ -93,7 +93,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:postgres')]
     - as: xmlfiles8
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles8.filepaths}}'
@@ -102,7 +102,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'postgres')]
     - as: xmlfiles9
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles9.filepaths}}'
@@ -111,7 +111,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:microsoft:sqlserver')]
     - as: xmlfiles10
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles10.filepaths}}'
@@ -120,7 +120,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'sqlserver')]
     - as: xmlfiles11
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles11.filepaths}}'
@@ -129,7 +129,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:sybase')]
     - as: xmlfiles12
       builtin.file:
-        pattern: .*-ds\.xml
+        pattern: ([^/\\]+)-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles12.filepaths}}'

--- a/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
+++ b/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
@@ -30,7 +30,7 @@
     or:
     - as: xmlfiles1
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml$
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles1.filepaths}}'
@@ -39,7 +39,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:db2')]
     - as: xmlfiles2
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles2.filepaths}}'
@@ -48,7 +48,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'db2')]
     - as: xmlfiles3
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles3.filepaths}}'
@@ -57,7 +57,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:mysql')]
     - as: xmlfiles4
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles4.filepaths}}'
@@ -66,7 +66,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'mysql')]
     - as: xmlfiles5
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles5.filepaths}}'
@@ -75,7 +75,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:oracle')]
     - as: xmlfiles6
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles6.filepaths}}'
@@ -93,7 +93,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:postgres')]
     - as: xmlfiles8
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles8.filepaths}}'
@@ -102,7 +102,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'postgres')]
     - as: xmlfiles9
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles9.filepaths}}'
@@ -111,7 +111,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:microsoft:sqlserver')]
     - as: xmlfiles10
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles10.filepaths}}'
@@ -120,7 +120,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'sqlserver')]
     - as: xmlfiles11
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles11.filepaths}}'
@@ -129,7 +129,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:sybase')]
     - as: xmlfiles12
       builtin.file:
-        pattern: ([^/\\]+)-ds\.xml
+        pattern: .*-ds\.xml
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles12.filepaths}}'

--- a/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
+++ b/default/generated/azure/12-eap-to-azure-appservice-datasource-driver.windup.yaml
@@ -30,7 +30,7 @@
     or:
     - as: xmlfiles1
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles1.filepaths}}'
@@ -39,7 +39,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:db2')]
     - as: xmlfiles2
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles2.filepaths}}'
@@ -48,7 +48,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'db2')]
     - as: xmlfiles3
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles3.filepaths}}'
@@ -57,7 +57,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:mysql')]
     - as: xmlfiles4
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles4.filepaths}}'
@@ -66,7 +66,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'mysql')]
     - as: xmlfiles5
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles5.filepaths}}'
@@ -75,7 +75,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:oracle')]
     - as: xmlfiles6
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles6.filepaths}}'
@@ -84,7 +84,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'oracle')]
     - as: xmlfiles7
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles7.filepaths}}'
@@ -93,7 +93,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:postgres')]
     - as: xmlfiles8
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles8.filepaths}}'
@@ -102,7 +102,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'postgres')]
     - as: xmlfiles9
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles9.filepaths}}'
@@ -111,7 +111,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:microsoft:sqlserver')]
     - as: xmlfiles10
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles10.filepaths}}'
@@ -120,7 +120,7 @@
         xpath: /datasources/drivers/driver/xa-datasource-class[contains(text(),'sqlserver')]
     - as: xmlfiles11
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles11.filepaths}}'
@@ -129,7 +129,7 @@
         xpath: /datasources/datasource/connection-url[contains(text(),'jdbc:sybase')]
     - as: xmlfiles12
       builtin.file:
-        pattern: ([a-zA-Z0-9._-]+)-ds\.xml$
+        pattern: ^([a-zA-Z0-9._-]+)-ds\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles12.filepaths}}'

--- a/default/generated/azure/14-jetty-to-azure-external-resources.windup.yaml
+++ b/default/generated/azure/14-jetty-to-azure-external-resources.windup.yaml
@@ -13,7 +13,7 @@
 # limitations under the License. 
 - category: optional
   customVariables: []
-  description: External resources found in configuration file
+  description: External resources found in Jetty configuration file
   effort: 5
   labels:
   - konveyor.io/target=azure-spring-apps

--- a/default/generated/azure/15-spring-boot-to-azure-config-server.windup.yaml
+++ b/default/generated/azure/15-spring-boot-to-azure-config-server.windup.yaml
@@ -30,7 +30,7 @@
   - Spring Cloud Config
   when:
     builtin.filecontent:
-      filePattern: .*\.(properties|yaml|yml)
+      filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
       pattern: spring\.config\.import|spring\.cloud\.config\.uri
 - category: potential
   customVariables: []

--- a/default/generated/azure/16-spring-boot-to-azure-eureka.windup.yaml
+++ b/default/generated/azure/16-spring-boot-to-azure-eureka.windup.yaml
@@ -28,5 +28,5 @@
   - Eureka
   when:
     builtin.filecontent:
-      filePattern: .*\.(properties|yaml|yml)
+      filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
       pattern: eureka\.client\.(service-url|serviceUrl)

--- a/default/generated/azure/17-spring-boot-to-azure-port.windup.yaml
+++ b/default/generated/azure/17-spring-boot-to-azure-port.windup.yaml
@@ -20,5 +20,5 @@
   ruleID: spring-boot-to-azure-port-01000
   when:
     builtin.filecontent:
-      filePattern: .*\.(properties|yaml|yml)
+      filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
       pattern: (^|\s)server\.port

--- a/default/generated/azure/18-spring-boot-to-azure-restricted-config.windup.yaml
+++ b/default/generated/azure/18-spring-boot-to-azure-restricted-config.windup.yaml
@@ -38,5 +38,5 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: .*\.(properties|yaml|yml)
+        filePattern: (/|\\)(application|bootstrap)(-[a-zA-Z0-9]+)*?\.(properties|yaml|yml)$
         pattern: (eureka\.client\.(serviceUrl\.defaultZone|service-url\.defaultZone))|(eureka\.client\.tls\.keystore)|(eureka\.instance\.preferIpAddress)|(eureka\.instance\.instance-id)|(server\.port)|(spring\.cloud\.config\.tls\.keystore)|(spring\.config\.import)|(spring\.application\.name)|(spring\.jmx\.enabled)|(management\.endpoints\.jmx\.exposure\.include)

--- a/default/generated/azure/22-tomcat-to-azure-external-resources.windup.yaml
+++ b/default/generated/azure/22-tomcat-to-azure-external-resources.windup.yaml
@@ -1,6 +1,6 @@
 - category: optional
   customVariables: []
-  description: External resources found in configuration file
+  description: External resources found in Tomcat configuration file
   effort: 5
   labels:
   - konveyor.io/target=azure-spring-apps

--- a/default/generated/cloud-readiness/01-embedded-cache.windup.yaml
+++ b/default/generated/cloud-readiness/01-embedded-cache.windup.yaml
@@ -16,7 +16,7 @@
   - Caching - Ehcache embedded library
   when:
     builtin.file:
-      pattern: .*ehcache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)ehcache([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Coherence embedded library
@@ -35,7 +35,7 @@
   - Caching - Coherence embedded library
   when:
     builtin.file:
-      pattern: .*coherence.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)coherence([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Apache Commons JCS embedded library
@@ -54,7 +54,7 @@
   - Caching - Apache Commons JCS embedded library
   when:
     builtin.file:
-      pattern: .*commons-jcs.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)commons-jcs([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Dynacache embedded library
@@ -73,7 +73,7 @@
   - Caching - Dynacache embedded library
   when:
     builtin.file:
-      pattern: .*dynacache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)dynacache([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Embedded library
@@ -92,7 +92,7 @@
   - Caching - Embedded library
   when:
     builtin.file:
-      pattern: .*cache-api.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)cache-api([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Hazelcast embedded library
@@ -111,7 +111,7 @@
   - Caching - Hazelcast embedded library
   when:
     builtin.file:
-      pattern: .*hazelcast.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)hazelcast([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Apache Ignite embedded library
@@ -130,7 +130,7 @@
   - Caching - Apache Ignite embedded library
   when:
     builtin.file:
-      pattern: .*ignite.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)ignite([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Infinispan embedded library
@@ -149,7 +149,7 @@
   - Caching - Infinispan embedded library
   when:
     builtin.file:
-      pattern: .*infinispan.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)infinispan([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - JBoss Cache embedded library
@@ -168,7 +168,7 @@
   - Caching - JBoss Cache embedded library
   when:
     builtin.file:
-      pattern: .*jbosscache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)jbosscache([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - JCache embedded library
@@ -187,7 +187,7 @@
   - Caching - JCache embedded library
   when:
     builtin.file:
-      pattern: .*jcache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)jcache([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Memcached client embedded library
@@ -206,7 +206,7 @@
   - Caching - Memcached client embedded library
   when:
     builtin.file:
-      pattern: .*memcached.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)memcached([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Oscache embedded library
@@ -225,7 +225,7 @@
   - Caching - Oscache embedded library
   when:
     builtin.file:
-      pattern: .*oscache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)oscache([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - ShiftOne (Java Object Cache) embedded library
@@ -244,7 +244,7 @@
   - Caching - ShiftOne (Java Object Cache) embedded library
   when:
     builtin.file:
-      pattern: .*shiftone.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)shiftone([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - SwarmCache embedded library
@@ -263,7 +263,7 @@
   - Caching - SwarmCache embedded library
   when:
     builtin.file:
-      pattern: .*swarmcache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)swarmcache([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Caching - Spring Boot Cache library
@@ -306,4 +306,4 @@
   - Caching - Redis Cache library
   when:
     builtin.file:
-      pattern: .*redis.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)redis([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/cloud-readiness/05-jca.windup.yaml
+++ b/default/generated/cloud-readiness/05-jca.windup.yaml
@@ -21,4 +21,4 @@
   ruleID: jca-00000
   when:
     builtin.file:
-      pattern: ra\.xml
+      pattern: ^ra\.xml$

--- a/default/generated/cloud-readiness/07-local-storage.windup.yaml
+++ b/default/generated/cloud-readiness/07-local-storage.windup.yaml
@@ -134,7 +134,7 @@
   ruleID: local-storage-00003
   when:
     builtin.filecontent:
-      filePattern: .*(\\.java|\\.properties|\\.jsp|\\.jspf|\\.tag|[^pom]\\.xml|\\.txt)
+      filePattern: (/|\\)(?!pom\.xml$)([a-zA-Z0-9._-]+)\.(java|properties|jsp|jspf|tag|xml|txt)$
       pattern: (\W|\s|^)([a-zA-Z]\:|\\\\(\w+\.?)+)([\\\/][^\n\t]+)+
 - category: mandatory
   customVariables: []
@@ -175,7 +175,7 @@
   ruleID: local-storage-00004
   when:
     builtin.filecontent:
-      filePattern: .*\.(\\\.java|\\\.properties|\\\.jsp|\\\.jspf|\\\.tag|[^pom]\\\.xml|\\\.txt)
+      filePattern: (/|\\)(?!pom\.xml$)([a-zA-Z0-9._-]+)\.(java|properties|jsp|jspf|tag|xml|txt)$
       pattern: file://
 - category: mandatory
   customVariables: []

--- a/default/generated/cloud-readiness/08-localhost.windup.yaml
+++ b/default/generated/cloud-readiness/08-localhost.windup.yaml
@@ -12,7 +12,7 @@
   ruleID: localhost-http-00001
   when:
     builtin.filecontent:
-      filePattern: .*\.(java|properties|jsp|jspf|tag|xml|txt|yaml)
+      filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(java|properties|jsp|jspf|tag|xml|txt|yaml)$
       pattern: http(s)?://((localhost)|(127\.0\.0\.1))+(:[0-9]+)?(/.*)?
 - category: mandatory
   customVariables: []
@@ -28,7 +28,7 @@
   ruleID: localhost-jdbc-00002
   when:
     builtin.filecontent:
-      filePattern: .*\.(java|properties|jsp|jspf|tag|xml|txt|yaml)
+      filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(java|properties|jsp|jspf|tag|xml|txt|yaml)$
       pattern: jdbc:([a-z0-9-]+)://(localhost|127\.0\.0\.1)(:[0-9]+)?
 - category: mandatory
   customVariables: []
@@ -44,5 +44,5 @@
   ruleID: localhost-ws-00003
   when:
     builtin.filecontent:
-      filePattern: .*\.(java|properties|jsp|jspf|tag|xml|txt|yaml)
+      filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(java|properties|jsp|jspf|tag|xml|txt|yaml)$
       pattern: ws(s)?://((localhost)|(127\.0\.0\.1))+(:[0-9]+)?(/.*)?

--- a/default/generated/cloud-readiness/09-logging.windup.yaml
+++ b/default/generated/cloud-readiness/09-logging.windup.yaml
@@ -89,8 +89,8 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: log(?:back|4j).*\.(xml|properties)
+        filePattern: log(?:back|4j)([a-zA-Z0-9._-]*)\.(xml|properties)$
         pattern: (?i)\b(?:Daily)?Rolling?FileAppender\b|type\s*=\s*['"]?(?:Daily)?Rolling?File['"]?|<\/\s*(?:Daily)?Rolling?File\s*>
     - builtin.filecontent:
-        filePattern: log(?:back|4j).*\.(xml|properties)
+        filePattern: log(?:back|4j)([a-zA-Z0-9._-]*)\.(xml|properties)$
         pattern: appender-ref ref=.FILE

--- a/default/generated/cloud-readiness/09-logging.windup.yaml
+++ b/default/generated/cloud-readiness/09-logging.windup.yaml
@@ -1,6 +1,6 @@
 - category: mandatory
   customVariables: []
-  description: Don't log to file system
+  description: Avoid File System Logging in Java Code
   effort: 1
   labels:
   - konveyor.io/source=java
@@ -63,7 +63,7 @@
       pattern: java.util.logging.SocketHandler*
 - category: mandatory
   customVariables: []
-  description: Don't log to file system
+  description: Avoid File System Logging in Configuration
   effort: 1
   labels:
   - konveyor.io/source=java

--- a/default/generated/openjdk21/01-deprecation-openjdk18.windup.yaml
+++ b/default/generated/openjdk21/01-deprecation-openjdk18.windup.yaml
@@ -1,6 +1,6 @@
 - category: potential
   customVariables: []
-  description: Deprecated method in JDK 18 for removal in future release
+  description: Deprecated signature `doAs` in JDK 18 for removal in future release
   effort: 3
   labels:
   - konveyor.io/source=openjdk18-
@@ -17,7 +17,7 @@
       pattern: javax.security.auth.Subject.doAs
 # - category: mandatory
 #   customVariables: []
-#   description: Deprecated method in JDK 18 for removal in future release
+#   description: Deprecated method `Thread.stop()` in JDK 18 for removal in future release
 #   effort: 3
 #   labels:
 #   - konveyor.io/source=openjdk18-

--- a/default/generated/os/01-os-specific.windup.yaml
+++ b/default/generated/os/01-os-specific.windup.yaml
@@ -25,7 +25,7 @@
   ruleID: os-specific-00001
   when:
     builtin.filecontent:
-      filePattern: .*\.(java|properties|jsp|jspf|tag|xml|txt)
+      filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(java|properties|jsp|jspf|tag|xml|txt)$
       pattern: (\W|\s|^)([a-zA-Z]\:|\\\\(\w+\.?)+)([\\\/][^\n\t]+)+
 - category: mandatory
   customVariables: []
@@ -46,4 +46,4 @@
   ruleID: os-specific-00002
   when:
     builtin.file:
-      pattern: .*\.dll
+      pattern: ^([a-zA-Z0-9._-]+)\.dll$


### PR DESCRIPTION
### Scope
- azure
- openjdk 11/17/21
- cloud-readiness
- os

### Findings

1. currently no multi-line matching support for file content pattern, which is hardcoded in lsp source code.
2. better to specify start or end point for file name or file path pattern.
3. avoid greedy matching as much as possible.
4. when `builtin.file`, 
    - the `pattern` is the regex of **file name, which should be specified start point ^**.
5. when `builtin.filecontent`, 
    - the `pattern` is the regex of **file content, which can NOT be specified start point ^**.
    - the `filepattern` is the regex of **file path, which should be specified the path separator**.