### PR TITLE
Update rules regex

### DIFF
--- a/default/generated/technology-usage/04-3rd-party.windup.yaml
+++ b/default/generated/technology-usage/04-3rd-party.windup.yaml
@@ -10,7 +10,7 @@
   - Embedded framework - Liferay
   when:
     builtin.file:
-      pattern: .*liferay.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)liferay([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Oracle Forms
   labels:
@@ -23,7 +23,7 @@
   - Embedded framework - Oracle Forms
   when:
     builtin.file:
-      pattern: .*frm.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)frm([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring Boot
   labels:
@@ -40,7 +40,7 @@
         lowerbound: 0.0.0
         name: org.springframework.spring-boot
     - builtin.file:
-        pattern: spring-boot.*\.jar
+        pattern: ^spring-boot([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Elasticsearch
   labels:
@@ -53,7 +53,7 @@
   - Embedded framework - Elasticsearch
   when:
     builtin.file:
-      pattern: .*elasticsearch.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)elasticsearch([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded library - Logstash
@@ -82,9 +82,9 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*logstash.*
+        nameregex: ([a-zA-Z0-9._-]*)logstash([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: .*logstash.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)logstash([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Jetty
   labels:
@@ -97,7 +97,7 @@
   - Embedded framework - Jetty
   when:
     builtin.file:
-      pattern: .*jetty.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jetty([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Tomcat
   labels:
@@ -110,7 +110,7 @@
   - Embedded framework - Tomcat
   when:
     builtin.file:
-      pattern: .*tomcat.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)tomcat([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Kibana
   labels:
@@ -123,7 +123,7 @@
   - Embedded framework - Kibana
   when:
     builtin.file:
-      pattern: .*kibana.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)kibana([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache Karaf
   labels:
@@ -136,7 +136,7 @@
   - Embedded framework - Apache Karaf
   when:
     builtin.file:
-      pattern: .*karaf.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)karaf([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Neo4j
   labels:
@@ -149,7 +149,7 @@
   - Embedded framework - Neo4j
   when:
     builtin.file:
-      pattern: .*neo4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)neo4j([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spark
   labels:
@@ -162,7 +162,7 @@
   - Embedded framework - Spark
   when:
     builtin.file:
-      pattern: .*spark-.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)spark-([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache Hadoop
   labels:
@@ -175,7 +175,7 @@
   - Embedded framework - Apache Hadoop
   when:
     builtin.file:
-      pattern: .*hadoop.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)hadoop([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache Geronimo
   labels:
@@ -188,7 +188,7 @@
   - Embedded framework - Apache Geronimo
   when:
     builtin.file:
-      pattern: .*geronimo.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)geronimo([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache Aries
   labels:
@@ -201,7 +201,7 @@
   - Embedded framework - Apache Aries
   when:
     builtin.file:
-      pattern: .*aries.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)aries([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Cloudera
   labels:
@@ -214,7 +214,7 @@
   - Embedded framework - Cloudera
   when:
     builtin.file:
-      pattern: .*cloudera.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)cloudera([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - MapR
   labels:
@@ -227,7 +227,7 @@
   - Embedded framework - MapR
   when:
     builtin.file:
-      pattern: .*mapr.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mapr([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - TensorFlow
   labels:
@@ -240,7 +240,7 @@
   - Embedded framework - TensorFlow
   when:
     builtin.file:
-      pattern: .*tensorflow.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)tensorflow([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Weka
   labels:
@@ -253,7 +253,7 @@
   - Embedded framework - Weka
   when:
     builtin.file:
-      pattern: .*weka.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)weka([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache Mahout
   labels:
@@ -266,7 +266,7 @@
   - Embedded framework - Apache Mahout
   when:
     builtin.file:
-      pattern: .*mahout.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mahout([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded library - Splunk
@@ -295,9 +295,9 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*splunk.*
+        nameregex: ([a-zA-Z0-9._-]*)splunk([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: .*splunk.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)splunk([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Nacos
   labels:
@@ -315,10 +315,10 @@
         name: com.alibaba.nacos.nacos-client
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: com\.alibaba\.cloud\.spring-cloud-starter-alibaba-nacos-.*
+        nameregex: com\.alibaba\.cloud\.spring-cloud-starter-alibaba-nacos-([a-zA-Z0-9._-]*)
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: com\.alibaba\.boot\.nacos-.*-spring-boot-starter
+        nameregex: com\.alibaba\.boot\.nacos-([a-zA-Z0-9._-]*)-spring-boot-starter
 - customVariables: []
   description: Embedded framework - Sentinel
   labels:
@@ -333,10 +333,10 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: com\.alibaba\.csp\.sentinel-.*
+        nameregex: com\.alibaba\.csp\.sentinel-([a-zA-Z0-9._-]*)
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: com\.alibaba\.cloud\.spring-cloud-alibaba-sentinel-.*
+        nameregex: com\.alibaba\.cloud\.spring-cloud-alibaba-sentinel-([a-zA-Z0-9._-]*)
     - java.dependency:
         lowerbound: 0.0.0
         name: com.alibaba.cloud.spring-cloud-starter-alibaba-sentinel

--- a/default/generated/technology-usage/06-apm.windup.yaml
+++ b/default/generated/technology-usage/06-apm.windup.yaml
@@ -23,9 +23,9 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: com\.microsoft\.azure\..*applicationinsights.*
+        nameregex: com\.microsoft\.azure\.([a-zA-Z0-9._-]*)applicationinsights([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: applicationinsights.*\.jar
+        pattern: ^applicationinsights([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Application Performance Management (APM) tool - New Relic
@@ -49,9 +49,9 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*newrelic.*
+        nameregex: ([a-zA-Z0-9._-]*)newrelic([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: newrelic.*\.jar
+        pattern: ^newrelic([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Application Performance Management (APM) tool - Elastic APM
@@ -81,9 +81,9 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*elastic\.apm.*
+        nameregex: ([a-zA-Z0-9._-]*)elastic\.apm([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: elastic-apm.*\.jar
+        pattern: ^elastic-apm([a-zA-Z0-9._-]*)\.jar$
 - category: mandatory
   customVariables: []
   description: Application Performance Management (APM) tool - Dynatrace
@@ -108,8 +108,8 @@
   when:
     or:
     - builtin.file:
-        pattern: dynatrace.*\.jar
+        pattern: ^dynatrace([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: liboneagent\.so
+        pattern: ^liboneagent\.so$
     - builtin.file:
-        pattern: dtjavaagent\.jar
+        pattern: ^dtjavaagent\.jar$

--- a/default/generated/technology-usage/07-security-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/07-security-technology-usage.windup.yaml
@@ -19,7 +19,7 @@
         xpath: //*[local-name() = 'login-config']/*[local-name() = 'realm-name']
     - as: xmlfiles2
       builtin.file:
-        pattern: .*ejb-jar\.xml
+        pattern: ^([a-zA-Z0-9._-]*)ejb-jar\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles2.filepaths}}'

--- a/default/generated/technology-usage/192-configuration-management.windup.yaml
+++ b/default/generated/technology-usage/192-configuration-management.windup.yaml
@@ -44,7 +44,7 @@
   - Application properties file detected
   when:
     builtin.file:
-      pattern: application.*\.(properties|yml|yaml)
+      pattern: ^application(-[a-zA-Z0-9]+)*?\.(properties|yml|yaml)$
 - customVariables: []
   description: Spring datasource properties detected
   labels:
@@ -57,7 +57,7 @@
   - Spring datasource properties detected
   when:
     builtin.filecontent:
-      filePattern: application.*\.(properties|yml|yaml)
+      filePattern: (/|\\)application(-[a-zA-Z0-9]+)*?\.(properties|yml|yaml)$
       pattern: spring.datasource
 - customVariables: []
   description: Spring logging properties detected
@@ -71,7 +71,7 @@
   - Spring logging properties detected
   when:
     builtin.filecontent:
-      filePattern: application.*\.(properties|yml|yaml)
+      filePattern: (/|\\)application(-[a-zA-Z0-9]+)*?\.(properties|yml|yaml)$
       pattern: logging.level.org.springframework
 - customVariables: []
   description: Spring configuration properties annotation detected
@@ -124,7 +124,7 @@
         lowerbound: 0.0.0
         name: org.springframework.cloud.spring-cloud-vault-config
     - builtin.filecontent:
-        filePattern: .*\.{extensions}
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.{extensions}$
         pattern: spring.cloud.vault
     - builtin.file:
-        pattern: .*spring-cloud-vault.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)spring-cloud-vault([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/194-connect.windup.yaml
+++ b/default/generated/technology-usage/194-connect.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded Resource Adapter
   when:
     builtin.file:
-      pattern: .*\.rar
+      pattern: ^([a-zA-Z0-9._-]+)\.rar$
 - category: potential
   customVariables: []
   description: ActiveMQ found
@@ -59,9 +59,9 @@
         name: org.springframework.boot.spring-boot-starter-activemq
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: org\.apache\.activemq\..*
+        nameregex: org\.apache\.activemq\.([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: .*activemq.*
+        pattern: ^([a-zA-Z0-9._-]*)activemq([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - OpenWS
   labels:
@@ -73,7 +73,7 @@
   - Embedded library - OpenWS
   when:
     builtin.file:
-      pattern: .*openws.*
+      pattern: ^([a-zA-Z0-9._-]*)openws([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - WSDL
   labels:
@@ -85,7 +85,7 @@
   - Embedded library - WSDL
   when:
     builtin.file:
-      pattern: .*wsdl.*
+      pattern: ^([a-zA-Z0-9._-]*)wsdl([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - RabbitMQ Client
   labels:
@@ -98,15 +98,15 @@
   when:
     or:
     - builtin.file:
-        pattern: .*amqp-client.*
+        pattern: ^([a-zA-Z0-9._-]*)amqp-client([a-zA-Z0-9._-]*)$
     - builtin.file:
-        pattern: .*rabbitmq.*
+        pattern: ^([a-zA-Z0-9._-]*)rabbitmq([a-zA-Z0-9._-]*)$
     - builtin.file:
-        pattern: .*spring-rabbit.*
+        pattern: ^([a-zA-Z0-9._-]*)spring-rabbit([a-zA-Z0-9._-]*)$
     - builtin.file:
-        pattern: .*lyra.*
+        pattern: ^([a-zA-Z0-9._-]*)lyra([a-zA-Z0-9._-]*)$
     - builtin.file:
-        pattern: .*conduit.*
+        pattern: ^([a-zA-Z0-9._-]*)conduit([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - Spring Messaging Client
   labels:
@@ -119,9 +119,9 @@
   when:
     or:
     - builtin.file:
-        pattern: .*spring-messaging.*
+        pattern: ^([a-zA-Z0-9._-]*)spring-messaging([a-zA-Z0-9._-]*)$
     - builtin.file:
-        pattern: .*spring-jms.*
+        pattern: ^([a-zA-Z0-9._-]*)spring-jms([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - Camel Messaging Client
   labels:
@@ -133,7 +133,7 @@
   - Embedded library - Camel Messaging Client
   when:
     builtin.file:
-      pattern: .*camel-jms.*
+      pattern: ^([a-zA-Z0-9._-]*)camel-jms([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - Amazon SQS Client
   labels:
@@ -145,7 +145,7 @@
   - Embedded library - Amazon SQS Client
   when:
     builtin.file:
-      pattern: .*aws-java-sdk-sqs.*
+      pattern: ^([a-zA-Z0-9._-]*)aws-java-sdk-sqs([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - HornetQ Client
   labels:
@@ -157,7 +157,7 @@
   - Embedded library - HornetQ Client
   when:
     builtin.file:
-      pattern: .*hornetq.*
+      pattern: ^([a-zA-Z0-9._-]*)hornetq([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - AMQP Client
   labels:
@@ -169,7 +169,7 @@
   - Embedded library - AMQP Client
   when:
     builtin.file:
-      pattern: .*amqp.*
+      pattern: ^([a-zA-Z0-9._-]*)amqp([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - RocketMQ Client
   labels:
@@ -181,7 +181,7 @@
   - Embedded library - RocketMQ Client
   when:
     builtin.file:
-      pattern: .*rocketmq-client.*
+      pattern: ^([a-zA-Z0-9._-]*)rocketmq-client([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - 0MQ Client
   labels:
@@ -194,9 +194,9 @@
   when:
     or:
     - builtin.file:
-        pattern: .*jzmq.*
+        pattern: ^([a-zA-Z0-9._-]*)jzmq([a-zA-Z0-9._-]*)$
     - builtin.file:
-        pattern: .*jeromq.*
+        pattern: ^([a-zA-Z0-9._-]*)jeromq([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - JBossMQ Client
   labels:
@@ -208,7 +208,7 @@
   - Embedded library - JBossMQ Client
   when:
     builtin.file:
-      pattern: .*jbossmq-client.*
+      pattern: ^([a-zA-Z0-9._-]*)jbossmq-client([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - Zbus Client
   labels:
@@ -220,7 +220,7 @@
   - Embedded library - Zbus Client
   when:
     builtin.file:
-      pattern: .*zbus-client.*
+      pattern: ^([a-zA-Z0-9._-]*)zbus-client([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - Qpid Client
   labels:
@@ -232,7 +232,7 @@
   - Embedded library - Qpid Client
   when:
     builtin.file:
-      pattern: .*qpid.*
+      pattern: ^([a-zA-Z0-9._-]*)qpid([a-zA-Z0-9._-]*)$
 - customVariables: []
   description: Embedded library - Kafka Client
   labels:
@@ -245,6 +245,6 @@
   when:
     or:
     - builtin.file:
-        pattern: .*kafka-clients.*
+        pattern: ^([a-zA-Z0-9._-]*)kafka-clients([a-zA-Z0-9._-]*)$
     - builtin.file:
-        pattern: .*spring-kafka.*
+        pattern: ^([a-zA-Z0-9._-]*)spring-kafka([a-zA-Z0-9._-]*)$

--- a/default/generated/technology-usage/196-database.windup.yaml
+++ b/default/generated/technology-usage/196-database.windup.yaml
@@ -109,7 +109,7 @@
         nameregex: ([a-zA-Z0-9._-]*)postgresql([a-zA-Z0-9._-]*)
     - builtin.filecontent:
         filePattern: build\.gradle$
-        pattern: ^postgresql
+        pattern: postgresql
     - builtin.file:
         pattern: ^([a-zA-Z0-9._-]*)postgresql([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []

--- a/default/generated/technology-usage/196-database.windup.yaml
+++ b/default/generated/technology-usage/196-database.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded HSQLDB Driver
   when:
     builtin.file:
-      pattern: .*hsqldb.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)hsqldb([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: MySQL database found
@@ -49,12 +49,12 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*mysql.*
+        nameregex: ([a-zA-Z0-9._-]*)mysql([a-zA-Z0-9._-]*)
     - builtin.filecontent:
-        filePattern: build\.gradle
+        filePattern: build\.gradle$
         pattern: mysql
     - builtin.file:
-        pattern: .*mysql-connector.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)mysql-connector([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded Derby Driver
   labels:
@@ -66,7 +66,7 @@
   - Embedded Derby Driver
   when:
     builtin.file:
-      pattern: .*derby.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)derby([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: PostgreSQL database found
@@ -106,12 +106,12 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*postgresql.*
+        nameregex: ([a-zA-Z0-9._-]*)postgresql([a-zA-Z0-9._-]*)
     - builtin.filecontent:
-        filePattern: build\.gradle
-        pattern: postgresql
+        filePattern: build\.gradle$
+        pattern: ^postgresql
     - builtin.file:
-        pattern: .*postgresql.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)postgresql([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded H2 Driver
   labels:
@@ -123,7 +123,7 @@
   - Embedded H2 Driver
   when:
     builtin.file:
-      pattern: .*h2.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)h2([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded Microsoft SQL Driver
   labels:
@@ -136,9 +136,9 @@
   when:
     or:
     - builtin.file:
-        pattern: sqljdbc.*\.jar
+        pattern: ^sqljdbc([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: mssql-jdbc.*\.jar
+        pattern: ^mssql-jdbc([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Microsoft SQL database found
@@ -177,9 +177,9 @@
   when:
     or:
     - builtin.file:
-        pattern: sqljdbc.*\.jar
+        pattern: ^sqljdbc([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: mssql-jdbc.*\.jar
+        pattern: ^mssql-jdbc([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded Oracle DB Driver
   labels:
@@ -192,9 +192,9 @@
   when:
     or:
     - builtin.file:
-        pattern: .*jodbc.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)jodbc([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*ojdbc.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)ojdbc([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded Cassandra Client
   labels:
@@ -207,23 +207,23 @@
   when:
     or:
     - builtin.file:
-        pattern: .*sqlite-jdbc.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)sqlite-jdbc([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*cassandra.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)cassandra([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*hector.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)hector([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*astyanax.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)astyanax([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*phantom-dsl.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)phantom-dsl([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*cql.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)cql([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*hecuba-client.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)hecuba-client([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*c-star-path.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)c-star-path([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*scale7-pelops.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)scale7-pelops([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Cassandra database found
@@ -260,21 +260,21 @@
   when:
     or:
     - builtin.file:
-        pattern: .*cassandra.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)cassandra([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*hector.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)hector([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*astyanax.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)astyanax([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*phantom-dsl.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)phantom-dsl([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*cql.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)cql([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*hecuba-client.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)hecuba-client([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*c-star-path.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)c-star-path([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*scale7-pelops.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)scale7-pelops([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded MckoiSQLDB Driver
   labels:
@@ -286,7 +286,7 @@
   - Embedded MckoiSQLDB Driver
   when:
     builtin.file:
-      pattern: .*mckoisqldb.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mckoisqldb([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded MongoDB Client
   labels:
@@ -299,17 +299,17 @@
   when:
     or:
     - builtin.file:
-        pattern: .*mongodb.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)mongodb([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*casbah.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)casbah([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*reactivemongo.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)reactivemongo([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*jongo.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)jongo([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*gmongo.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)gmongo([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*rogue.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)rogue([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: MongoDB database found
@@ -346,17 +346,17 @@
   when:
     or:
     - builtin.file:
-        pattern: .*mongodb.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)mongodb([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*casbah.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)casbah([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*reactivemongo.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)reactivemongo([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*jongo.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)jongo([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*gmongo.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)gmongo([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*rogue.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)rogue([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Morphia
   labels:
@@ -368,7 +368,7 @@
   - Embedded framework - Morphia
   when:
     builtin.file:
-      pattern: .*morphia.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)morphia([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded LevelDB Client
   labels:
@@ -380,7 +380,7 @@
   - Embedded LevelDB Client
   when:
     builtin.file:
-      pattern: .*leveldb.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)leveldb([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded Apache HBase Client
   labels:
@@ -392,7 +392,7 @@
   - Embedded Apache HBase Client
   when:
     builtin.file:
-      pattern: .*hbase.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)hbase([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded Apache Accumulo Client
   labels:
@@ -404,7 +404,7 @@
   - Embedded Apache Accumulo Client
   when:
     builtin.file:
-      pattern: .*accumulo.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)accumulo([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded Spring Data JPA
   labels:
@@ -437,7 +437,7 @@
   - Embedded MariaDB Driver
   when:
     builtin.file:
-      pattern: .*mariadb.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mariadb([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: MariaDB database found
@@ -475,4 +475,4 @@
   - MariaDB Driver
   when:
     builtin.file:
-      pattern: .*mariadb.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mariadb([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/201-embedded-framework.windup.yaml
+++ b/default/generated/technology-usage/201-embedded-framework.windup.yaml
@@ -10,7 +10,7 @@
   - Embedded framework - Apache Axis
   when:
     builtin.file:
-      pattern: axis.*\.jar
+      pattern: ^axis([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache Axis2
   labels:
@@ -23,7 +23,7 @@
   - Embedded framework - Apache Axis2
   when:
     builtin.file:
-      pattern: axis2.*\.jar
+      pattern: ^axis2([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache CXF
   labels:
@@ -36,7 +36,7 @@
   - Embedded framework - Apache CXF
   when:
     builtin.file:
-      pattern: .*cxf.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)cxf([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - XFire
   labels:
@@ -49,7 +49,7 @@
   - Embedded framework - XFire
   when:
     builtin.file:
-      pattern: .*xfire.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)xfire([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Jersey
   labels:
@@ -62,7 +62,7 @@
   - Embedded framework - Jersey
   when:
     builtin.file:
-      pattern: .*jersey.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jersey([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Unirest
   labels:
@@ -75,7 +75,7 @@
   - Embedded framework - Unirest
   when:
     builtin.file:
-      pattern: .*unirest.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)unirest([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Hibernate
   labels:
@@ -88,7 +88,7 @@
   - Embedded framework - Hibernate
   when:
     builtin.file:
-      pattern: hibernate.*\.jar
+      pattern: ^hibernate([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Hibernate OGM
   labels:
@@ -101,7 +101,7 @@
   - Embedded framework - Hibernate OGM
   when:
     builtin.file:
-      pattern: hibernate-ogm.*\.jar
+      pattern: ^hibernate-ogm([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - EclipseLink
   labels:
@@ -114,7 +114,7 @@
   - Embedded framework - EclipseLink
   when:
     builtin.file:
-      pattern: .*eclipselink.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)eclipselink([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring Batch
   labels:
@@ -127,7 +127,7 @@
   - Embedded framework - Spring Batch
   when:
     builtin.file:
-      pattern: spring-batch.*\.jar
+      pattern: ^spring-batch([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - AspectJ
   labels:
@@ -140,7 +140,7 @@
   - Embedded framework - AspectJ
   when:
     builtin.file:
-      pattern: .*aspectj.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)aspectj([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JBPM
   labels:
@@ -153,7 +153,7 @@
   - Embedded framework - JBPM
   when:
     builtin.file:
-      pattern: .*jbpm.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jbpm([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - iLog
   labels:
@@ -166,7 +166,7 @@
   - Embedded framework - iLog
   when:
     builtin.file:
-      pattern: .*jrules.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jrules([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Camunda
   labels:
@@ -179,7 +179,7 @@
   - Embedded framework - Camunda
   when:
     builtin.file:
-      pattern: .*camunda.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)camunda([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Pega
   labels:
@@ -192,7 +192,7 @@
   - Embedded framework - Pega
   when:
     builtin.file:
-      pattern: .*pega.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)pega([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Blaze
   labels:
@@ -205,7 +205,7 @@
   - Embedded framework - Blaze
   when:
     builtin.file:
-      pattern: blaze.*\.jar
+      pattern: ^blaze([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - MRules
   labels:
@@ -218,7 +218,7 @@
   - Embedded framework - MRules
   when:
     builtin.file:
-      pattern: .*MRules.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)MRules([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Easy Rules
   labels:
@@ -231,7 +231,7 @@
   - Embedded framework - Easy Rules
   when:
     builtin.file:
-      pattern: .*easy-rules.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)easy-rules([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - AOP Alliance
   labels:
@@ -244,7 +244,7 @@
   - Embedded framework - AOP Alliance
   when:
     builtin.file:
-      pattern: .*aopalliance.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)aopalliance([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - SNMP4J
   labels:
@@ -257,7 +257,7 @@
   - Embedded framework - SNMP4J
   when:
     builtin.file:
-      pattern: .*snmp4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)snmp4j([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - HTTP Client
   labels:
@@ -270,7 +270,7 @@
   - Embedded framework - HTTP Client
   when:
     builtin.file:
-      pattern: .*http-client.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)http-client([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Javax Inject
   labels:
@@ -284,9 +284,9 @@
   when:
     or:
     - builtin.file:
-        pattern: javax\.inject.*\.jar
+        pattern: ^javax\.inject([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*atinject.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)atinject([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Google Guice
   labels:
@@ -299,7 +299,7 @@
   - Embedded framework - Google Guice
   when:
     builtin.file:
-      pattern: .*guice.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)guice([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - CDI
   labels:
@@ -312,7 +312,7 @@
   - Embedded framework - CDI
   when:
     builtin.file:
-      pattern: .*cdi.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)cdi([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Plexus Container
   labels:
@@ -325,7 +325,7 @@
   - Embedded framework - Plexus Container
   when:
     builtin.file:
-      pattern: .*plexus-container.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)plexus-container([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Weld
   labels:
@@ -338,7 +338,7 @@
   - Embedded framework - Weld
   when:
     builtin.file:
-      pattern: .*weld.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)weld([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Dagger
   labels:
@@ -351,7 +351,7 @@
   - Embedded framework - Dagger
   when:
     builtin.file:
-      pattern: dagger.*\.jar
+      pattern: ^dagger([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - GIN
   labels:
@@ -364,7 +364,7 @@
   - Embedded framework - GIN
   when:
     builtin.file:
-      pattern: gin.*\.jar
+      pattern: ^gin([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - PicoContainer
   labels:
@@ -377,7 +377,7 @@
   - Embedded framework - PicoContainer
   when:
     builtin.file:
-      pattern: .*picocontainer.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)picocontainer([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Scaldi
   labels:
@@ -390,7 +390,7 @@
   - Embedded framework - Scaldi
   when:
     builtin.file:
-      pattern: .*scaldi.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)scaldi([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Macros
   labels:
@@ -403,7 +403,7 @@
   - Embedded framework - Macros
   when:
     builtin.file:
-      pattern: macros.*\.jar
+      pattern: ^macros([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Injekt for Kotlin
   labels:
@@ -416,7 +416,7 @@
   - Embedded framework - Injekt for Kotlin
   when:
     builtin.file:
-      pattern: injekt-core.*\.jar
+      pattern: ^injekt-core([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Kodein
   labels:
@@ -429,7 +429,7 @@
   - Embedded framework - Kodein
   when:
     builtin.file:
-      pattern: kodein.*\.jar
+      pattern: ^kodein([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Peaberry
   labels:
@@ -442,7 +442,7 @@
   - Embedded framework - Peaberry
   when:
     builtin.file:
-      pattern: peaberry.*\.jar
+      pattern: ^peaberry([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Sticky Configured
   labels:
@@ -455,7 +455,7 @@
   - Embedded framework - Sticky Configured
   when:
     builtin.file:
-      pattern: sticky-configured.*\.jar
+      pattern: ^sticky-configured([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Ka DI
   labels:
@@ -468,7 +468,7 @@
   - Embedded framework - Ka DI
   when:
     builtin.file:
-      pattern: ka-di.*\.jar
+      pattern: ^ka-di([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Polyforms DI
   labels:
@@ -481,7 +481,7 @@
   - Embedded framework - Polyforms DI
   when:
     builtin.file:
-      pattern: polyforms-di.*\.jar
+      pattern: ^polyforms-di([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JayWire
   labels:
@@ -494,7 +494,7 @@
   - Embedded framework - JayWire
   when:
     builtin.file:
-      pattern: jaywire.*\.jar
+      pattern: ^jaywire([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Silk DI
   labels:
@@ -507,7 +507,7 @@
   - Embedded framework - Silk DI
   when:
     builtin.file:
-      pattern: silk-di.*\.jar
+      pattern: ^silk-di([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Grapht DI
   labels:
@@ -520,7 +520,7 @@
   - Embedded framework - Grapht DI
   when:
     builtin.file:
-      pattern: grapht.*\.jar
+      pattern: ^grapht([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Syringe
   labels:
@@ -533,7 +533,7 @@
   - Embedded framework - Syringe
   when:
     builtin.file:
-      pattern: syringe.*\.jar
+      pattern: ^syringe([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Cfg Engine
   labels:
@@ -546,7 +546,7 @@
   - Embedded framework - Cfg Engine
   when:
     builtin.file:
-      pattern: cfg-engine.*\.jar
+      pattern: ^cfg-engine([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - BeanInject
   labels:
@@ -559,7 +559,7 @@
   - Embedded framework - BeanInject
   when:
     builtin.file:
-      pattern: beaninject.*\.jar
+      pattern: ^beaninject([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Tornado Inject
   labels:
@@ -572,7 +572,7 @@
   - Embedded framework - Tornado Inject
   when:
     builtin.file:
-      pattern: inject.*\.jar
+      pattern: ^inject([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Airframe
   labels:
@@ -585,7 +585,7 @@
   - Embedded framework - Airframe
   when:
     builtin.file:
-      pattern: airframe.*\.jar
+      pattern: ^airframe([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Winter
   labels:
@@ -598,7 +598,7 @@
   - Embedded framework - Winter
   when:
     builtin.file:
-      pattern: winter.*\.jar
+      pattern: ^winter([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - KouInject
   labels:
@@ -611,7 +611,7 @@
   - Embedded framework - KouInject
   when:
     builtin.file:
-      pattern: kouinject.*\.jar
+      pattern: ^kouinject([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Iroh
   labels:
@@ -624,7 +624,7 @@
   - Embedded framework - Iroh
   when:
     builtin.file:
-      pattern: iroh.*\.jar
+      pattern: ^iroh([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Micro DI
   labels:
@@ -637,7 +637,7 @@
   - Embedded framework - Micro DI
   when:
     builtin.file:
-      pattern: micro-di.*\.jar
+      pattern: ^micro-di([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - SubCut
   labels:
@@ -650,7 +650,7 @@
   - Embedded framework - SubCut
   when:
     builtin.file:
-      pattern: subcut.*\.jar
+      pattern: ^subcut([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring DI
   labels:
@@ -726,7 +726,7 @@
   - Embedded framework - Spring Boot Flo
   when:
     builtin.filecontent:
-      filePattern: .*\.(html|ts)
+      filepattern: (/|\\)([a-zA-Z0-9._-]+)\.(html|ts)$
       pattern: (<|')flo-editor
 - customVariables: []
   description: Embedded framework - Spring Scheduled
@@ -772,7 +772,7 @@
   - Embedded framework - Quartz
   when:
     builtin.file:
-      pattern: .*quartz.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)quartz([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded framework - Feign
@@ -795,12 +795,12 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: com\.netflix\.feign\..*
+        nameregex: com\.netflix\.feign\.([a-zA-Z0-9._-]*)
     - java.dependency:
         lowerbound: 0.0.0
         name: org.springframework.cloud.spring-cloud-starter-feign
     - builtin.file:
-        pattern: feign-.*\.jar
+        pattern: ^feign-([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded framework - Zipkin
@@ -832,9 +832,9 @@
         name: org.springframework.boot.spring-cloud-starter-zipkin
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: io\.zipkin.*
+        nameregex: io\.zipkin([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: .*zipkin.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)zipkin([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded framework - Eureka Client
@@ -863,9 +863,9 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*eureka-client.*
+        nameregex: ([a-zA-Z0-9._-]*)eureka-client([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: .*eureka-client.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)eureka-client([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded framework - Eureka Server
@@ -891,6 +891,6 @@
     or:
     - java.dependency:
         lowerbound: 0.0.0
-        nameregex: .*eureka-server.*
+        nameregex: ([a-zA-Z0-9._-]*)eureka-server([a-zA-Z0-9._-]*)
     - builtin.file:
-        pattern: .*eureka-server.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)eureka-server([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/204-integration.windup.yaml
+++ b/default/generated/technology-usage/204-integration.windup.yaml
@@ -204,4 +204,4 @@
   when:
     java.referenced:
       location: IMPORT
-      pattern: ^org.springframework.integration.dsl.IntegrationFlow
+      pattern: org.springframework.integration.dsl.IntegrationFlow

--- a/default/generated/technology-usage/204-integration.windup.yaml
+++ b/default/generated/technology-usage/204-integration.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded library - Apache Camel
   when:
     builtin.file:
-      pattern: .*camel.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)camel([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Teiid
   labels:
@@ -21,7 +21,7 @@
   - Embedded library - Teiid
   when:
     builtin.file:
-      pattern: .*teiid.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)teiid([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring Integration
   labels:
@@ -33,7 +33,7 @@
   - Embedded framework - Spring Integration
   when:
     builtin.file:
-      pattern: spring-integration.*\.jar
+      pattern: ^spring-integration([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Ikasan
   labels:
@@ -45,7 +45,7 @@
   - Embedded framework - Ikasan
   when:
     builtin.file:
-      pattern: .*ikasan.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)ikasan([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Swagger
   labels:
@@ -57,7 +57,7 @@
   - Embedded framework - Swagger
   when:
     builtin.file:
-      pattern: .*swagger.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)swagger([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apiman
   labels:
@@ -69,7 +69,7 @@
   - Embedded framework - Apiman
   when:
     builtin.file:
-      pattern: .*apiman.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)apiman([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - 3scale
   labels:
@@ -81,7 +81,7 @@
   - Embedded framework - 3scale
   when:
     builtin.file:
-      pattern: .*3scale.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)3scale([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Istio
   labels:
@@ -93,7 +93,7 @@
   - Embedded framework - Istio
   when:
     builtin.file:
-      pattern: .*istio.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)istio([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - ServiceMix
   labels:
@@ -105,7 +105,7 @@
   - Embedded framework - ServiceMix
   when:
     builtin.file:
-      pattern: .*servicemix.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)servicemix([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Mule
   labels:
@@ -117,7 +117,7 @@
   - Embedded framework - Mule
   when:
     builtin.file:
-      pattern: .*mule.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mule([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Petals EIP
   labels:
@@ -129,7 +129,7 @@
   - Embedded framework - Petals EIP
   when:
     builtin.file:
-      pattern: .*petals.*eip.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)petals([a-zA-Z0-9._-]*)eip([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - SwitchYard
   labels:
@@ -141,7 +141,7 @@
   - Embedded framework - SwitchYard
   when:
     builtin.file:
-      pattern: .*switchyard.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)switchyard([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Apache Synapse
   labels:
@@ -153,7 +153,7 @@
   - Embedded framework - Apache Synapse
   when:
     builtin.file:
-      pattern: .*synapse.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)synapse([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - WSO2
   labels:
@@ -165,7 +165,7 @@
   - Embedded framework - WSO2
   when:
     builtin.file:
-      pattern: .*wso2.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)wso2([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Talend ESB
   labels:
@@ -177,7 +177,7 @@
   - Embedded framework - Talend ESB
   when:
     builtin.file:
-      pattern: .*talend.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)talend([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring Integration
   labels:
@@ -204,4 +204,4 @@
   when:
     java.referenced:
       location: IMPORT
-      pattern: org.springframework.integration.dsl.IntegrationFlow
+      pattern: ^org.springframework.integration.dsl.IntegrationFlow

--- a/default/generated/technology-usage/209-jta.windup.yaml
+++ b/default/generated/technology-usage/209-jta.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded library - Mycontainer JTA
   when:
     builtin.file:
-      pattern: mycontainer-jta.*\.jar
+      pattern: ^mycontainer-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Geronimo JTA
   labels:
@@ -21,7 +21,7 @@
   - Embedded library - Geronimo JTA
   when:
     builtin.file:
-      pattern: geronimo-jta.*\.jar
+      pattern: ^geronimo-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OW2 JTA
   labels:
@@ -33,7 +33,7 @@
   - Embedded library - OW2 JTA
   when:
     builtin.file:
-      pattern: ow2-jta.*\.jar
+      pattern: ^ow2-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Evo JTA
   labels:
@@ -45,7 +45,7 @@
   - Embedded library - Evo JTA
   when:
     builtin.file:
-      pattern: evo-jta.*\.jar
+      pattern: ^evo-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - AKKA JTA
   labels:
@@ -57,7 +57,7 @@
   - Embedded library - AKKA JTA
   when:
     builtin.file:
-      pattern: akka-jta.*\.jar
+      pattern: ^akka-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - KumuluzEE JTA
   labels:
@@ -69,7 +69,7 @@
   - Embedded library - KumuluzEE JTA
   when:
     builtin.file:
-      pattern: kumuluzee-jta.*\.jar
+      pattern: ^kumuluzee-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Ignite JTA
   labels:
@@ -81,7 +81,7 @@
   - Embedded library - Ignite JTA
   when:
     builtin.file:
-      pattern: ignite-jta.*\.jar
+      pattern: ^ignite-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Nuxeo JTA/JCA
   labels:
@@ -93,7 +93,7 @@
   - Embedded library - Nuxeo JTA/JCA
   when:
     builtin.file:
-      pattern: nuxeo-runtime-jtajca.*\.jar
+      pattern: ^nuxeo-runtime-jtajca([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Everit JTA
   labels:
@@ -105,7 +105,7 @@
   - Embedded library - Everit JTA
   when:
     builtin.file:
-      pattern: org\.everit\.transaction\.propagator\.jta.*\.jar
+      pattern: ^org\.everit\.transaction\.propagator\.jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Demoiselle JTA
   labels:
@@ -117,7 +117,7 @@
   - Embedded library - Demoiselle JTA
   when:
     builtin.file:
-      pattern: demoiselle-jta.*\.jar
+      pattern: ^demoiselle-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Meecrowave JTA
   labels:
@@ -129,7 +129,7 @@
   - Embedded library - Apache Meecrowave JTA
   when:
     builtin.file:
-      pattern: meecrowave-jta.*\.jar
+      pattern: ^meecrowave-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Sirona JTA
   labels:
@@ -141,7 +141,7 @@
   - Embedded library - Apache Sirona JTA
   when:
     builtin.file:
-      pattern: sirona-jta.*\.jar
+      pattern: ^sirona-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Lift JTA
   labels:
@@ -153,7 +153,7 @@
   - Embedded library - Lift JTA
   when:
     builtin.file:
-      pattern: lift-jta.*\.jar
+      pattern: ^lift-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - WF Core JTA
   labels:
@@ -165,7 +165,7 @@
   - Embedded library - WF Core JTA
   when:
     builtin.file:
-      pattern: wf-core-jta.*\.jar
+      pattern: ^wf-core-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Java Transaction API (JTA)
   labels:
@@ -178,9 +178,9 @@
   when:
     or:
     - builtin.file:
-        pattern: jta.*\.jar
+        pattern: ^jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: javax-jta.*\.jar
+        pattern: ^javax-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JBoss Transactions
   labels:
@@ -193,21 +193,21 @@
   when:
     or:
     - builtin.file:
-        pattern: jboss.*jta.*\.jar
+        pattern: ^jboss([a-zA-Z0-9._-]*)jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: jboss.*jts.*\.jar
+        pattern: ^jboss([a-zA-Z0-9._-]*)jts([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: jbossxts.*\.jar
+        pattern: ^jbossxts([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: jbossts.*\.jar
+        pattern: ^jbossts([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: arquillian-transaction-jta.*\.jar
+        pattern: ^arquillian-transaction-jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: weld-jta.*\.jar
+        pattern: ^weld-jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: wildfly.*jta.*\.jar
+        pattern: ^wildfly([a-zA-Z0-9._-]*)jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: transactions.*\.jar
+        pattern: ^transactions([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - GlassFish JTA
   labels:
@@ -220,11 +220,11 @@
   when:
     or:
     - builtin.file:
-        pattern: glassfish-jta.*\.jar
+        pattern: ^glassfish-jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: osgi-jta.*\.jar
+        pattern: ^osgi-jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: jta-l10n.*\.jar
+        pattern: ^jta-l10n([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Atomikos JTA
   labels:
@@ -237,11 +237,11 @@
   when:
     or:
     - builtin.file:
-        pattern: transactions-jta.*\.jar
+        pattern: ^transactions-jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: ks-jta.*\.jar
+        pattern: ^ks-jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: evo-jta-atomikos.*\.jar
+        pattern: ^evo-jta-atomikos([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Narayana Arjuna
   labels:
@@ -254,11 +254,11 @@
   when:
     or:
     - builtin.file:
-        pattern: .*narayana.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)narayana([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*arjuna.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)arjuna([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: tomcat-jta.*\.jar
+        pattern: ^tomcat-jta([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Spring Transactions
   labels:
@@ -271,6 +271,6 @@
   when:
     or:
     - builtin.file:
-        pattern: spring-.*jta.*\.jar
+        pattern: ^spring-([a-zA-Z0-9._-]*)jta([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: insight-plugin-jta.*\.jar
+        pattern: ^insight-plugin-jta([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/21-javaee-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/21-javaee-technology-usage.windup.yaml
@@ -26,7 +26,7 @@
     or:
     - as: xmlfiles1
       builtin.file:
-        pattern: .*\.xml
+        pattern: ^([a-zA-Z0-9._-]+)\.xml$
       ignore: true
     - builtin.xml:
         filepaths: '{{xmlfiles1.filepaths}}'
@@ -168,7 +168,7 @@
   - Java EE Application Deployment
   when:
     builtin.file:
-      pattern: .*\.ear
+      pattern: ^([a-zA-Z0-9._-]+)\.ear$
 - customVariables: []
   description: Web Services Metadata
   labels:
@@ -211,7 +211,7 @@
 - customVariables:
   - name: package
     nameOfCaptureGroup: package
-    pattern: (?P<package>java|javax.)?xml.bind..*
+    pattern: (?P<package>java|javax.)?xml.bind.([a-zA-Z0-9._-]*)
   description: JAXB
   labels:
   - konveyor.io/include=always

--- a/default/generated/technology-usage/211-logging-usage.windup.yaml
+++ b/default/generated/technology-usage/211-logging-usage.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded library - Apache Log4J
   when:
     builtin.file:
-      pattern: .*log4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)log4j([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Commons Logging
   labels:
@@ -21,7 +21,7 @@
   - Embedded library - Apache Commons Logging
   when:
     builtin.file:
-      pattern: .*commons-logging.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)commons-logging([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - SLF4J
   labels:
@@ -33,7 +33,7 @@
   - Embedded library - SLF4J
   when:
     builtin.file:
-      pattern: .*slf4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)slf4j([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - tinylog
   labels:
@@ -45,7 +45,7 @@
   - Embedded library - tinylog
   when:
     builtin.file:
-      pattern: .*tinylog.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)tinylog([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Logback
   labels:
@@ -57,7 +57,7 @@
   - Embedded library - Logback
   when:
     builtin.file:
-      pattern: .*logback.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)logback([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JBoss logging
   labels:
@@ -69,7 +69,7 @@
   - Embedded library - JBoss logging
   when:
     builtin.file:
-      pattern: .*jboss-logging.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jboss-logging([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Monolog
   labels:
@@ -81,7 +81,7 @@
   - Embedded library - Monolog
   when:
     builtin.file:
-      pattern: .*monolog.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)monolog([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Jcabi Log
   labels:
@@ -93,7 +93,7 @@
   - Embedded library - Jcabi Log
   when:
     builtin.file:
-      pattern: .*jcabi-log.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jcabi-log([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - NLOG4J
   labels:
@@ -105,7 +105,7 @@
   - Embedded library - NLOG4J
   when:
     builtin.file:
-      pattern: .*nlog4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)nlog4j([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Log4s
   labels:
@@ -117,7 +117,7 @@
   - Embedded library - Log4s
   when:
     builtin.file:
-      pattern: log4s.*\.jar
+      pattern: ^log4s([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Kotlin Logging
   labels:
@@ -129,7 +129,7 @@
   - Embedded library - Kotlin Logging
   when:
     builtin.file:
-      pattern: .*kotlin-logging.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)kotlin-logging([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Airlift Log Manager
   labels:
@@ -141,7 +141,7 @@
   - Embedded library - Airlift Log Manager
   when:
     builtin.file:
-      pattern: log-manager.*\.jar
+      pattern: ^log-manager([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - MinLog
   labels:
@@ -153,7 +153,7 @@
   - Embedded library - MinLog
   when:
     builtin.file:
-      pattern: .*minilog.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)minilog([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Logging Utils
   labels:
@@ -165,7 +165,7 @@
   - Embedded library - Logging Utils
   when:
     builtin.file:
-      pattern: logging.*\.jar
+      pattern: ^logging([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OCPsoft Logging Utils
   labels:
@@ -177,7 +177,7 @@
   - Embedded library - OCPsoft Logging Utils
   when:
     builtin.file:
-      pattern: logging-api.*\.jar
+      pattern: ^logging-api([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Scribe
   labels:
@@ -189,7 +189,7 @@
   - Embedded library - Scribe
   when:
     builtin.file:
-      pattern: .*scribe.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)scribe([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - GFC Logging
   labels:
@@ -201,7 +201,7 @@
   - Embedded library - GFC Logging
   when:
     builtin.file:
-      pattern: .*gfc-logging.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)gfc-logging([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Blitz4j
   labels:
@@ -213,7 +213,7 @@
   - Embedded library - Blitz4j
   when:
     builtin.file:
-      pattern: .*blitz4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)blitz4j([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Avalon Logkit
   labels:
@@ -225,7 +225,7 @@
   - Embedded library - Avalon Logkit
   when:
     builtin.file:
-      pattern: .*avalon-logkit.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)avalon-logkit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - KLogger
   labels:
@@ -237,7 +237,7 @@
   - Embedded library - KLogger
   when:
     builtin.file:
-      pattern: .*klogger.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)klogger([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Lumberjack
   labels:
@@ -249,7 +249,7 @@
   - Embedded library - Lumberjack
   when:
     builtin.file:
-      pattern: .*lumberjack.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)lumberjack([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Log.io
   labels:
@@ -261,7 +261,7 @@
   - Embedded library - Log.io
   when:
     builtin.file:
-      pattern: .*logio.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)logio([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OPS4J Pax Logging Service
   labels:
@@ -273,7 +273,7 @@
   - Embedded library - OPS4J Pax Logging Service
   when:
     builtin.file:
-      pattern: .*pax-logging-service.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)pax-logging-service([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OW2 Log Util
   labels:
@@ -285,7 +285,7 @@
   - Embedded library - OW2 Log Util
   when:
     builtin.file:
-      pattern: util-log.*\.jar
+      pattern: ^util-log([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Twitter Util Logging
   labels:
@@ -297,7 +297,7 @@
   - Embedded library - Twitter Util Logging
   when:
     builtin.file:
-      pattern: util-logging.*\.jar
+      pattern: ^util-logging([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Composite Logging JCL
   labels:
@@ -309,7 +309,7 @@
   - Embedded library - Composite Logging JCL
   when:
     builtin.file:
-      pattern: composite-logging-api.*\.jar
+      pattern: ^composite-logging-api([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Flume
   labels:
@@ -321,4 +321,4 @@
   - Embedded library - Apache Flume
   when:
     builtin.file:
-      pattern: .*flume.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)flume([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/215-mvc.windup.yaml
+++ b/default/generated/technology-usage/215-mvc.windup.yaml
@@ -46,7 +46,7 @@
   when:
     java.referenced:
       location: ANNOTATION
-      pattern: ^org.springframework.web.servlet.mvc.Controller
+      pattern: org.springframework.web.servlet.mvc.Controller
 - customVariables: []
   description: Embedded framework - Spring MVC
   labels:

--- a/default/generated/technology-usage/215-mvc.windup.yaml
+++ b/default/generated/technology-usage/215-mvc.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded library - Apache Wicket
   when:
     builtin.file:
-      pattern: .*wicket.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)wicket([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Struts
   labels:
@@ -21,7 +21,7 @@
   - Embedded library - Apache Struts
   when:
     builtin.file:
-      pattern: .*struts.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)struts([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring MVC
   labels:
@@ -33,7 +33,7 @@
   - Embedded framework - Spring MVC
   when:
     builtin.file:
-      pattern: .*spring-webmvc.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)spring-webmvc([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring MVC
   labels:
@@ -46,7 +46,7 @@
   when:
     java.referenced:
       location: ANNOTATION
-      pattern: org.springframework.web.servlet.mvc.Controller
+      pattern: ^org.springframework.web.servlet.mvc.Controller
 - customVariables: []
   description: Embedded framework - Spring MVC
   labels:
@@ -81,7 +81,7 @@
   - Embedded library - GWT
   when:
     builtin.file:
-      pattern: .*gwt.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)gwt([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - MyFaces
   labels:
@@ -93,7 +93,7 @@
   - Embedded library - MyFaces
   when:
     builtin.file:
-      pattern: .*myfaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)myfaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - RichFaces
   labels:
@@ -105,7 +105,7 @@
   - Embedded library - RichFaces
   when:
     builtin.file:
-      pattern: .*richfaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)richfaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JSF
   labels:
@@ -117,7 +117,7 @@
   - Embedded library - JSF
   when:
     builtin.file:
-      pattern: .*jsf.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jsf([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Tapestry
   labels:
@@ -129,7 +129,7 @@
   - Embedded library - Apache Tapestry
   when:
     builtin.file:
-      pattern: .*tapestry.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)tapestry([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Stripes
   labels:
@@ -141,7 +141,7 @@
   - Embedded library - Stripes
   when:
     builtin.file:
-      pattern: .*stripes.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)stripes([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Spark
   labels:
@@ -153,7 +153,7 @@
   - Embedded library - Spark
   when:
     builtin.file:
-      pattern: .*spark.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)spark([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Vaadin
   labels:
@@ -165,7 +165,7 @@
   - Embedded library - Vaadin
   when:
     builtin.file:
-      pattern: .*vaadin.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)vaadin([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Grails
   labels:
@@ -177,7 +177,7 @@
   - Embedded library - Grails
   when:
     builtin.file:
-      pattern: .*grails.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)grails([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Play
   labels:
@@ -189,7 +189,7 @@
   - Embedded library - Play
   when:
     builtin.file:
-      pattern: .*play.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)play([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Oracle ADF
   labels:
@@ -202,9 +202,9 @@
   when:
     or:
     - builtin.file:
-        pattern: adf-settings\.xml
+        pattern: ^adf-settings\.xml
     - builtin.file:
-        pattern: adfc-config\.xml
+        pattern: ^adfc-config\.xml
 - customVariables: []
   description: Embedded library - PrimeFaces
   labels:
@@ -216,7 +216,7 @@
   - Embedded library - PrimeFaces
   when:
     builtin.file:
-      pattern: .*primefaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)primefaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JSTL
   labels:
@@ -228,7 +228,7 @@
   - Embedded library - JSTL
   when:
     builtin.file:
-      pattern: .*jslt.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jslt([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OpenFaces
   labels:
@@ -240,7 +240,7 @@
   - Embedded library - OpenFaces
   when:
     builtin.file:
-      pattern: .*openfaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)openfaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JFreeChart
   labels:
@@ -252,7 +252,7 @@
   - Embedded library - JFreeChart
   when:
     builtin.file:
-      pattern: .*jfreechart.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jfreechart([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - BootsFaces
   labels:
@@ -264,7 +264,7 @@
   - Embedded library - BootsFaces
   when:
     builtin.file:
-      pattern: .*bootsfaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)bootsfaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - ICEfaces
   labels:
@@ -276,7 +276,7 @@
   - Embedded library - ICEfaces
   when:
     builtin.file:
-      pattern: .*icefaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)icefaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - BabbageFaces
   labels:
@@ -288,7 +288,7 @@
   - Embedded library - BabbageFaces
   when:
     builtin.file:
-      pattern: .*babbageFaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)babbageFaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Portlet
   labels:
@@ -300,7 +300,7 @@
   - Embedded library - Portlet
   when:
     builtin.file:
-      pattern: .*portlet.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)portlet([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - AngularFaces
   labels:
@@ -312,7 +312,7 @@
   - Embedded library - AngularFaces
   when:
     builtin.file:
-      pattern: .*angularFaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)angularFaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - LiferayFaces
   labels:
@@ -324,7 +324,7 @@
   - Embedded library - LiferayFaces
   when:
     builtin.file:
-      pattern: .*liferay-faces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)liferay-faces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Liferay
   labels:
@@ -336,7 +336,7 @@
   - Embedded library - Liferay
   when:
     builtin.file:
-      pattern: .*liferay.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)liferay([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - ButterFaces
   labels:
@@ -348,7 +348,7 @@
   - Embedded library - ButterFaces
   when:
     builtin.file:
-      pattern: .*butterfaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)butterfaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - HighFaces
   labels:
@@ -360,7 +360,7 @@
   - Embedded library - HighFaces
   when:
     builtin.file:
-      pattern: .*highfaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)highfaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - TieFaces
   labels:
@@ -372,7 +372,7 @@
   - Embedded library - TieFaces
   when:
     builtin.file:
-      pattern: .*tiefaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)tiefaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OmniFaces
   labels:
@@ -384,7 +384,7 @@
   - Embedded library - OmniFaces
   when:
     builtin.file:
-      pattern: .*omnifaces.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)omnifaces([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - UberFire
   labels:
@@ -396,7 +396,7 @@
   - Embedded library - UberFire
   when:
     builtin.file:
-      pattern: .*uberfire.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)uberfire([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Velocity
   labels:
@@ -408,7 +408,7 @@
   - Embedded library - Apache Velocity
   when:
     builtin.file:
-      pattern: .*velocity.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)velocity([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Thymeleaf
   labels:
@@ -420,7 +420,7 @@
   - Embedded library - Thymeleaf
   when:
     builtin.file:
-      pattern: .*thymeleaf.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)thymeleaf([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache FreeMarker
   labels:
@@ -432,7 +432,7 @@
   - Embedded library - Apache FreeMarker
   when:
     builtin.file:
-      pattern: .*freemarker.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)freemarker([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - ANTLR StringTemplate
   labels:
@@ -444,7 +444,7 @@
   - Embedded library - ANTLR StringTemplate
   when:
     builtin.file:
-      pattern: .*stringtemplate.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)stringtemplate([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Handlebars
   labels:
@@ -456,7 +456,7 @@
   - Embedded library - Handlebars
   when:
     builtin.file:
-      pattern: .*handlebars.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)handlebars([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JMustache
   labels:
@@ -468,7 +468,7 @@
   - Embedded library - JMustache
   when:
     builtin.file:
-      pattern: .*jmustache.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jmustache([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Jamon
   labels:
@@ -480,7 +480,7 @@
   - Embedded library - Jamon
   when:
     builtin.file:
-      pattern: jamon-.*\.jar
+      pattern: ^jamon-([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Twirl
   labels:
@@ -492,7 +492,7 @@
   - Embedded library - Twirl
   when:
     builtin.file:
-      pattern: .*twirl.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)twirl([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Scalate
   labels:
@@ -504,7 +504,7 @@
   - Embedded library - Scalate
   when:
     builtin.file:
-      pattern: .*scalate.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)scalate([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Rythm Template Engine
   labels:
@@ -516,7 +516,7 @@
   - Embedded library - Rythm Template Engine
   when:
     builtin.file:
-      pattern: .*rythm-engine.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)rythm-engine([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Trimou
   labels:
@@ -528,7 +528,7 @@
   - Embedded library - Trimou
   when:
     builtin.file:
-      pattern: .*trimou-core.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)trimou-core([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Jetbrick Template
   labels:
@@ -540,7 +540,7 @@
   - Embedded library - Jetbrick Template
   when:
     builtin.file:
-      pattern: .*velocity.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)velocity([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Chunk Templates
   labels:
@@ -552,7 +552,7 @@
   - Embedded library - Chunk Templates
   when:
     builtin.file:
-      pattern: .*chunk-templates.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)chunk-templates([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JSilver
   labels:
@@ -564,7 +564,7 @@
   - Embedded library - JSilver
   when:
     builtin.file:
-      pattern: .*jsilver.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jsilver([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Water Template Engine
   labels:
@@ -576,7 +576,7 @@
   - Embedded library - Water Template Engine
   when:
     builtin.file:
-      pattern: .*watertemplate-engine.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)watertemplate-engine([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Ickenham
   labels:
@@ -588,7 +588,7 @@
   - Embedded library - Ickenham
   when:
     builtin.file:
-      pattern: .*ickenham.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)ickenham([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Mixer
   labels:
@@ -600,7 +600,7 @@
   - Embedded library - Mixer
   when:
     builtin.file:
-      pattern: .*mixer.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mixer([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Webmacro
   labels:
@@ -612,7 +612,7 @@
   - Embedded library - Webmacro
   when:
     builtin.file:
-      pattern: .*webmacro.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)webmacro([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - DVSL
   labels:
@@ -624,7 +624,7 @@
   - Embedded library - DVSL
   when:
     builtin.file:
-      pattern: .*dvsl.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)dvsl([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Snippetory Template Engine
   labels:
@@ -636,7 +636,7 @@
   - Embedded library - Snippetory Template Engine
   when:
     builtin.file:
-      pattern: .*snippetory.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)snippetory([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Anakia
   labels:
@@ -648,4 +648,4 @@
   - Embedded library - Anakia
   when:
     builtin.file:
-      pattern: .*anakia.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)anakia([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/220-security.windup.yaml
+++ b/default/generated/technology-usage/220-security.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded framework - Spring Security
   when:
     builtin.file:
-      pattern: .*spring-security.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)spring-security([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Shiro
   labels:
@@ -21,7 +21,7 @@
   - Embedded library - Apache Shiro
   when:
     builtin.file:
-      pattern: .*shiro.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)shiro([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Hdiv
   labels:
@@ -33,7 +33,7 @@
   - Embedded library - Hdiv
   when:
     builtin.file:
-      pattern: .*hdiv.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)hdiv([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OACC
   labels:
@@ -45,7 +45,7 @@
   - Embedded library - OACC
   when:
     builtin.file:
-      pattern: .*acciente-oacc.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)acciente-oacc([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - PicketLink
   labels:
@@ -57,7 +57,7 @@
   - Embedded library - PicketLink
   when:
     builtin.file:
-      pattern: .*picketlink.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)picketlink([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - PicketBox
   labels:
@@ -69,7 +69,7 @@
   - Embedded library - PicketBox
   when:
     builtin.file:
-      pattern: .*picketbox.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)picketbox([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Keyczar
   labels:
@@ -81,7 +81,7 @@
   - Embedded library - Keyczar
   when:
     builtin.file:
-      pattern: .*keyczar.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)keyczar([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - XACML
   labels:
@@ -93,7 +93,7 @@
   - Embedded library - XACML
   when:
     builtin.file:
-      pattern: .*xacml.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)xacml([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded library - SAML
@@ -119,7 +119,7 @@
   - Embedded library - SAML
   when:
     builtin.file:
-      pattern: .*saml.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)saml([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Bouncy Castle
   labels:
@@ -132,17 +132,17 @@
   when:
     or:
     - builtin.file:
-        pattern: .*lcrypto.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)lcrypto([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*bcprov.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)bcprov([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*bcpg.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)bcpg([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*bcmail.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)bcmail([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*bcpkix.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)bcpkix([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*bctls.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)bctls([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Jasypt
   labels:
@@ -154,7 +154,7 @@
   - Embedded library - Jasypt
   when:
     builtin.file:
-      pattern: .*jasypt.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jasypt([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Santuario
   labels:
@@ -166,7 +166,7 @@
   - Embedded library - Apache Santuario
   when:
     builtin.file:
-      pattern: .*xmlsec.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)xmlsec([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - SSL
   labels:
@@ -178,7 +178,7 @@
   - Embedded library - SSL
   when:
     builtin.file:
-      pattern: .*ssl.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)ssl([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Vlad
   labels:
@@ -190,7 +190,7 @@
   - Embedded library - Vlad
   when:
     builtin.file:
-      pattern: vlad.*\.jar
+      pattern: ^vlad([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Apache Commons Validator
   labels:
@@ -202,7 +202,7 @@
   - Embedded library - Apache Commons Validator
   when:
     builtin.file:
-      pattern: commons-validator.*\.jar
+      pattern: ^commons-validator([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OWASP ESAPI
   labels:
@@ -214,7 +214,7 @@
   - Embedded library - OWASP ESAPI
   when:
     builtin.file:
-      pattern: .*esapi.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)esapi([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - WSS4J
   labels:
@@ -226,7 +226,7 @@
   - Embedded library - WSS4J
   when:
     builtin.file:
-      pattern: .*wss4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)wss4j([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded library - OpenSAML
@@ -252,7 +252,7 @@
   - Embedded library - OpenSAML
   when:
     builtin.file:
-      pattern: .*opensaml.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)opensaml([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OTR4J
   labels:
@@ -264,7 +264,7 @@
   - Embedded library - OTR4J
   when:
     builtin.file:
-      pattern: .*otr4j.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)otr4j([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OWASP CSRF Guard
   labels:
@@ -276,7 +276,7 @@
   - Embedded library - OWASP CSRF Guard
   when:
     builtin.file:
-      pattern: .*csrfguard.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)csrfguard([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - OAUTH
   labels:
@@ -288,7 +288,7 @@
   - Embedded library - OAUTH
   when:
     builtin.file:
-      pattern: .*oauth.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)oauth([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Acegi Security
   labels:
@@ -300,7 +300,7 @@
   - Embedded library - Acegi Security
   when:
     builtin.file:
-      pattern: .*acegi-security.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)acegi-security([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - JSecurity
   labels:
@@ -312,7 +312,7 @@
   - Embedded library - JSecurity
   when:
     builtin.file:
-      pattern: .*jsecurity.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jsecurity([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - AcrIS Security
   labels:
@@ -324,7 +324,7 @@
   - Embedded library - AcrIS Security
   when:
     builtin.file:
-      pattern: .*acris-security.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)acris-security([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - Trunk JGuard
   labels:
@@ -336,7 +336,7 @@
   - Embedded library - Trunk JGuard
   when:
     builtin.file:
-      pattern: .*jguard.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jguard([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded framework - Spring Security
@@ -402,7 +402,7 @@
   - OAuth 2.0
   when:
     builtin.file:
-      pattern: .*oauth2.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)oauth2([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Embedded library - OpenID
@@ -431,6 +431,6 @@
   when:
     or:
     - builtin.file:
-        pattern: .*openid4java.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)openid4java([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*pac4j-oidc.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)pac4j-oidc([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/221-spring-catchall.windup.yaml
+++ b/default/generated/technology-usage/221-spring-catchall.windup.yaml
@@ -9,4 +9,4 @@
   - Embedded framework - Spring
   when:
     builtin.file:
-      pattern: spring.*\.jar
+      pattern: ^spring([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/223-test-frameworks-usage.windup.yaml
+++ b/default/generated/technology-usage/223-test-frameworks-usage.windup.yaml
@@ -9,7 +9,7 @@
   - Embedded framework - EasyMock
   when:
     builtin.file:
-      pattern: .*easymock.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)easymock([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - PowerMock
   labels:
@@ -21,7 +21,7 @@
   - Embedded framework - PowerMock
   when:
     builtin.file:
-      pattern: .*powermock.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)powermock([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Mockito
   labels:
@@ -33,7 +33,7 @@
   - Embedded framework - Mockito
   when:
     builtin.file:
-      pattern: .*mockito.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)mockito([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - TestNG
   labels:
@@ -45,7 +45,7 @@
   - Embedded framework - TestNG
   when:
     builtin.file:
-      pattern: .*testng.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)testng([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Hamcrest
   labels:
@@ -57,7 +57,7 @@
   - Embedded framework - Hamcrest
   when:
     builtin.file:
-      pattern: .*hamcrest.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)hamcrest([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spring Test
   labels:
@@ -69,7 +69,7 @@
   - Embedded framework - Spring Test
   when:
     builtin.file:
-      pattern: spring.*test.*\.jar
+      pattern: ^spring([a-zA-Z0-9._-]*)test([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Spock
   labels:
@@ -81,7 +81,7 @@
   - Embedded framework - Spock
   when:
     builtin.file:
-      pattern: spock.*\.jar
+      pattern: ^spock([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - XMLUnit
   labels:
@@ -93,7 +93,7 @@
   - Embedded framework - XMLUnit
   when:
     builtin.file:
-      pattern: xmlunit.*\.jar
+      pattern: ^xmlunit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Akka Testkit
   labels:
@@ -105,7 +105,7 @@
   - Embedded framework - Akka Testkit
   when:
     builtin.file:
-      pattern: akka-testkit.*\.jar
+      pattern: ^akka-testkit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - REST Assured
   labels:
@@ -117,7 +117,7 @@
   - Embedded framework - REST Assured
   when:
     builtin.file:
-      pattern: rest-assured.*\.jar
+      pattern: ^rest-assured([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library - DbUnit
   labels:
@@ -129,7 +129,7 @@
   - Embedded library - DbUnit
   when:
     builtin.file:
-      pattern: dbunit.*\.jar
+      pattern: ^dbunit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Mule Functional Test Framework (TCK)
   labels:
@@ -141,7 +141,7 @@
   - Embedded framework - Mule Functional Test Framework (TCK)
   when:
     builtin.file:
-      pattern: mule-test.*\.jar
+      pattern: ^mule-test([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Guava Testing Library
   labels:
@@ -153,7 +153,7 @@
   - Embedded framework - Guava Testing Library
   when:
     builtin.file:
-      pattern: guava-testlib.*\.jar
+      pattern: ^guava-testlib([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - RandomizedTesting Randomized Runner
   labels:
@@ -165,7 +165,7 @@
   - Embedded framework - RandomizedTesting Randomized Runner
   when:
     builtin.file:
-      pattern: randomizedtesting-runner.*\.jar
+      pattern: ^randomizedtesting-runner([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - HttpUnit
   labels:
@@ -177,7 +177,7 @@
   - Embedded framework - HttpUnit
   when:
     builtin.file:
-      pattern: httpunit.*\.jar
+      pattern: ^httpunit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JCUnit
   labels:
@@ -189,7 +189,7 @@
   - Embedded framework - JCUnit
   when:
     builtin.file:
-      pattern: jcunit.*\.jar
+      pattern: ^jcunit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JPA Matchers
   labels:
@@ -201,7 +201,7 @@
   - Embedded framework - JPA Matchers
   when:
     builtin.file:
-      pattern: jpa-matchers.*\.jar
+      pattern: ^jpa-matchers([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - MultithreadedTC
   labels:
@@ -213,7 +213,7 @@
   - Embedded framework - MultithreadedTC
   when:
     builtin.file:
-      pattern: multithreadedtc.*\.jar
+      pattern: ^multithreadedtc([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Specsy
   labels:
@@ -225,7 +225,7 @@
   - Embedded framework - Specsy
   when:
     builtin.file:
-      pattern: specsy.*\.jar
+      pattern: ^specsy([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JFunk
   labels:
@@ -237,7 +237,7 @@
   - Embedded framework - JFunk
   when:
     builtin.file:
-      pattern: jfunk.*\.jar
+      pattern: ^jfunk([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Restito
   labels:
@@ -249,7 +249,7 @@
   - Embedded framework - Restito
   when:
     builtin.file:
-      pattern: restito.*\.jar
+      pattern: ^restito([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Test Interface
   labels:
@@ -261,7 +261,7 @@
   - Embedded framework - Test Interface
   when:
     builtin.file:
-      pattern: test-interface.*\.jar
+      pattern: ^test-interface([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Play Test
   labels:
@@ -273,7 +273,7 @@
   - Embedded framework - Play Test
   when:
     builtin.file:
-      pattern: play-test.*\.jar
+      pattern: ^play-test([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Arquillian
   labels:
@@ -285,7 +285,7 @@
   - Embedded framework - Arquillian
   when:
     builtin.file:
-      pattern: .*arquillian.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)arquillian([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Cactus
   labels:
@@ -297,7 +297,7 @@
   - Embedded framework - Cactus
   when:
     builtin.file:
-      pattern: .*cactus.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)cactus([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Concordion
   labels:
@@ -309,7 +309,7 @@
   - Embedded framework - Concordion
   when:
     builtin.file:
-      pattern: .*concordion.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)concordion([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Cucumber
   labels:
@@ -321,7 +321,7 @@
   - Embedded framework - Cucumber
   when:
     builtin.file:
-      pattern: .*cucumber.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)cucumber([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - EtlUnit
   labels:
@@ -333,7 +333,7 @@
   - Embedded framework - EtlUnit
   when:
     builtin.file:
-      pattern: .*etlunit.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)etlunit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - HavaRunner
   labels:
@@ -345,7 +345,7 @@
   - Embedded framework - HavaRunner
   when:
     builtin.file:
-      pattern: .*havarunner.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)havarunner([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JBehave
   labels:
@@ -357,7 +357,7 @@
   - Embedded framework - JBehave
   when:
     builtin.file:
-      pattern: .*jbehave.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jbehave([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JMock
   labels:
@@ -369,7 +369,7 @@
   - Embedded framework - JMock
   when:
     builtin.file:
-      pattern: .*jmock-.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jmock-([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JMockit
   labels:
@@ -381,7 +381,7 @@
   - Embedded framework - JMockit
   when:
     builtin.file:
-      pattern: .*jmockit.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jmockit([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Jukito
   labels:
@@ -393,7 +393,7 @@
   - Embedded framework - Jukito
   when:
     builtin.file:
-      pattern: .*jukito.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jukito([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Needle
   labels:
@@ -405,7 +405,7 @@
   - Embedded framework - Needle
   when:
     builtin.file:
-      pattern: .*needle.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)needle([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - OpenPojo
   labels:
@@ -417,7 +417,7 @@
   - Embedded framework - OpenPojo
   when:
     builtin.file:
-      pattern: .*openpojo.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)openpojo([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - Unitils
   labels:
@@ -429,7 +429,7 @@
   - Embedded framework - Unitils
   when:
     builtin.file:
-      pattern: .*unitils.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)unitils([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded framework - JUnit
   labels:
@@ -441,4 +441,4 @@
   - Embedded framework - JUnit
   when:
     builtin.file:
-      pattern: .*junit.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)junit([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/247-embedded-cache-libraries.windup.yaml
+++ b/default/generated/technology-usage/247-embedded-cache-libraries.windup.yaml
@@ -22,7 +22,7 @@
   - Ehcache
   when:
     builtin.file:
-      pattern: .*ehcache.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)ehcache([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Redis Cache library
@@ -69,7 +69,7 @@
         lowerbound: 0.0.0
         name: org.springframework.integration.spring-integration-redis
     - builtin.file:
-        pattern: .*redis.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)redis([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Coherence embedded library
   labels:
@@ -83,7 +83,7 @@
   - Coherence embedded library
   when:
     builtin.file:
-      pattern: .*coherence.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)coherence([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Apache Commons JCS embedded library
   labels:
@@ -97,7 +97,7 @@
   - Apache Commons JCS embedded library
   when:
     builtin.file:
-      pattern: .*commons-jcs.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)commons-jcs([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Dynacache embedded library
   labels:
@@ -111,7 +111,7 @@
   - Dynacache embedded library
   when:
     builtin.file:
-      pattern: .*dynacache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)dynacache([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded library
   labels:
@@ -125,7 +125,7 @@
   - Embedded library
   when:
     builtin.file:
-      pattern: .*cache-api.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)cache-api([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Hazelcast embedded library
   labels:
@@ -139,7 +139,7 @@
   - Hazelcast embedded library
   when:
     builtin.file:
-      pattern: .*hazelcast.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)hazelcast([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Apache Ignite embedded library
   labels:
@@ -153,7 +153,7 @@
   - Apache Ignite embedded library
   when:
     builtin.file:
-      pattern: .*ignite.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)ignite([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Infinispan embedded library
   labels:
@@ -167,7 +167,7 @@
   - Infinispan embedded library
   when:
     builtin.file:
-      pattern: .*infinispan.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)infinispan([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: JBoss Cache embedded library
   labels:
@@ -181,7 +181,7 @@
   - JBoss Cache embedded library
   when:
     builtin.file:
-      pattern: .*jbosscache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)jbosscache([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: JCache embedded library
   labels:
@@ -194,7 +194,7 @@
   - JCache embedded library
   when:
     builtin.file:
-      pattern: .*jcache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)jcache([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Memcached client embedded library
   labels:
@@ -208,7 +208,7 @@
   - Memcached client embedded library
   when:
     builtin.file:
-      pattern: .*memcached.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)memcached([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Oscache embedded library
   labels:
@@ -222,7 +222,7 @@
   - Oscache embedded library
   when:
     builtin.file:
-      pattern: .*oscache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)oscache([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: ShiftOne (Java Object Cache) embedded library
   labels:
@@ -236,7 +236,7 @@
   - ShiftOne (Java Object Cache) embedded library
   when:
     builtin.file:
-      pattern: .*shiftone.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)shiftone([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: SwarmCache embedded library
   labels:
@@ -250,7 +250,7 @@
   - SwarmCache embedded library
   when:
     builtin.file:
-      pattern: .*swarmcache.*\.jar$
+      pattern: ^([a-zA-Z0-9._-]*)swarmcache([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Spring Boot Cache library
   labels:
@@ -282,4 +282,4 @@
   - Redis Cache library
   when:
     builtin.file:
-      pattern: .*redis.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)redis([a-zA-Z0-9._-]*)\.jar$

--- a/default/generated/technology-usage/31-database-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/31-database-technology-usage.windup.yaml
@@ -39,13 +39,13 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: .*\.xml
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.xml$
         pattern: http://java.sun.com/xml/ns/persistence
     - builtin.filecontent:
-        filePattern: .*\.xml
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.xml$
         pattern: http://xmlns.jcp.org/xml/ns/persistence
     - builtin.filecontent:
-        filePattern: .*\.xml
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.xml$
         pattern: https://jakarta.ee/xml/ns/persistence
 - customVariables: []
   description: JPA Queries
@@ -101,7 +101,7 @@
   - Java EE=Persistence units
   when:
     builtin.file:
-      pattern: persistence\.xml
+      pattern: ^persistence\.xml$
 - customVariables: []
   description: HSQLDB Driver
   labels:

--- a/default/generated/technology-usage/33-connect-technology-usage.windup.yaml
+++ b/default/generated/technology-usage/33-connect-technology-usage.windup.yaml
@@ -128,7 +128,7 @@
         namespaces: {}
         xpath: //*[local-name()='jms-jca-provider']
     - builtin.file:
-        pattern: ra\.xml
+        pattern: ^ra\.xml$
 - customVariables: []
   labels:
   - konveyor.io/include=always

--- a/default/generated/technology-usage/42-web.windup.yaml
+++ b/default/generated/technology-usage/42-web.windup.yaml
@@ -10,7 +10,7 @@
   - Embedded technology - Java Server Faces
   when:
     builtin.filecontent:
-      filePattern: .*\.(jsp|xhtml|jspx)
+      filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(jsp|xhtml|jspx)$
       pattern: (java\.sun\.com/jsf/)|(xmlns\.jcp\.org/jsf)
 - customVariables: []
   description: Embedded technology - Java Server Pages
@@ -25,10 +25,10 @@
   when:
     or:
     - builtin.filecontent:
-        filePattern: .*\.(jsp|jspx|tag|tagx)
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(jsp|jspx|tag|tagx)$
         pattern: <%@\s*page\s+[^>]*\s*import\s*=\s*['"]([^'"]+)['"].*?%>
     - builtin.filecontent:
-        filePattern: .*\.(jsp|jspx|tag|tagx)
+        filePattern: (/|\\)([a-zA-Z0-9._-]+)\.(jsp|jspx|tag|tagx)$
         pattern: <%@\s*taglib\s+[^>]*\s*uri\s*=\s*['"]([^'"]+)['"].*?%>
 - customVariables: []
   description: Embedded technology - WebSocket
@@ -60,7 +60,7 @@
         location: INHERITANCE
         pattern: java.applet.Applet
     - builtin.file:
-        pattern: .*applet.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)applet([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded technology - JNLP
   labels:
@@ -73,7 +73,7 @@
   - Embedded technology - JNLP
   when:
     builtin.file:
-      pattern: .*\.jnlp
+      pattern: ^([a-zA-Z0-9._-]+)\.jnlp$
 - customVariables: []
   description: Embedded technology - JNLP
   labels:
@@ -87,9 +87,9 @@
   when:
     or:
     - builtin.file:
-        pattern: .*jnlp.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)jnlp([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*webstart.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)webstart([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: Java Swing usage
@@ -121,7 +121,7 @@
         location: IMPORT
         pattern: javax.swing*
     - builtin.file:
-        pattern: .*swing.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)swing([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded technology - MiGLayout
   labels:
@@ -134,7 +134,7 @@
   - Embedded technology - MiGLayout
   when:
     builtin.file:
-      pattern: .*miglayout.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)miglayout([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded technology - JGoodies
   labels:
@@ -147,7 +147,7 @@
   - Embedded technology - JGoodies
   when:
     builtin.file:
-      pattern: .*jgoodies.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)jgoodies([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded technology - FormLayoutMaker
   labels:
@@ -160,7 +160,7 @@
   - Embedded technology - FormLayoutMaker
   when:
     builtin.file:
-      pattern: .*formlayoutmakerx.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)formlayoutmakerx([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded technology - MagicGroupLayout
   labels:
@@ -173,7 +173,7 @@
   - Embedded technology - MagicGroupLayout
   when:
     builtin.file:
-      pattern: .*magicgrouplayout.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)magicgrouplayout([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded technology - Standard Widget Toolkit (SWT)
   labels:
@@ -186,7 +186,7 @@
   - Embedded technology - Standard Widget Toolkit (SWT)
   when:
     builtin.file:
-      pattern: .*swt.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)swt([a-zA-Z0-9._-]*)\.jar$
 - category: potential
   customVariables: []
   description: JavaFX usage
@@ -214,7 +214,7 @@
   - JavaFX
   when:
     builtin.file:
-      pattern: .*javafx.*\.jar
+      pattern: ^([a-zA-Z0-9._-]*)javafx([a-zA-Z0-9._-]*)\.jar$
 - customVariables: []
   description: Embedded technology - Eclipse RCP
   labels:
@@ -228,10 +228,10 @@
   when:
     or:
     - builtin.file:
-        pattern: rcp.*\.jar
+        pattern: ^rcp([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*eclipse\.rcp.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)eclipse\.rcp([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*eclipse.*runtime.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)eclipse([a-zA-Z0-9._-]*)runtime([a-zA-Z0-9._-]*)\.jar$
     - builtin.file:
-        pattern: .*eclipse\.ui.*\.jar
+        pattern: ^([a-zA-Z0-9._-]*)eclipse\.ui([a-zA-Z0-9._-]*)\.jar$


### PR DESCRIPTION
### Scope
- technology-usage

### Findings

1. currently no multi-line matching support for file content pattern, which is hardcoded in lsp source code.
2. better to specify start or end point for file name or file path pattern.
3. avoid greedy matching as much as possible.
4. when `builtin.file`, 
    - the `pattern` is the regex of **file name, which should be specified start point ^**.
5. when `builtin.filecontent`, 
    - the `pattern` is the regex of **file content, which can NOT be specified start point ^**.
    - the `filepattern` is the regex of **file path, which should be specified the path separator**.