### PR TITLE
Revert rule test

### DIFF
--- a/default/generated/azure/tests/10-azure-system-config.windup.test.yaml
+++ b/default/generated/azure/tests/10-azure-system-config.windup.test.yaml
@@ -4,12 +4,11 @@ providers:
   dataPath: ./data/10-azure-system-config
 - name: builtin
   dataPath: ./data/10-azure-system-config
-tests: []
-# https://github.com/konveyor/analyzer-lsp/issues/769
-# tests:
-# - ruleID: azure-system-config-01000
-#   testCases:
-#   - name: tc-1
-#     hasIncidents:
-#       atLeast: 2
-#       messageMatches: The application uses environment variables/system properties
+# https://github.com/konveyor/analyzer-lsp/issues/736#issuecomment-2504302330
+tests:
+- ruleID: azure-system-config-01000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      atLeast: 2
+      messageMatches: The application uses environment variables/system properties

--- a/default/generated/azure/tests/data/10-azure-system-config/src/main/java/org/sample/SystemGetEnvGetProperty.java
+++ b/default/generated/azure/tests/data/10-azure-system-config/src/main/java/org/sample/SystemGetEnvGetProperty.java
@@ -3,6 +3,8 @@
 // eap-to-azure-appservice-environment-variables-001
 package org.sample;
 
+import java.lang.System;
+
 public class SystemGetEnvGetProperty {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Revert the rule test for the rule `azure-system-config`.

--

The problem is that,

**the java file doesn't import the `java.lang.System` package, which may cause that the language server doesn't recognize and parse the `System.getenv` and `System.getProperty` methods.** So, even if we have correct rule definitions, it cannot match and test failed.

As a comparison, the rule `local-storage-00001` has correct condition definition, and it can correctly match because it has all packages imported in the java file.

However, we don't have to explicitly import anything from `java.lang`, because it is essential and universally needed, Java will automatically help us include it.

So the gap may be that the Java language server cannot automatically include the `java.lang` package.

