### PR TITLE
fix rule: sun.misc.unsafe and sun.reflect.Reflection

### DIFF
--- a/default/generated/openjdk11/java-11-deprecate-unsafe.yaml
+++ b/default/generated/openjdk11/java-11-deprecate-unsafe.yaml
@@ -53,5 +53,5 @@
   ruleID: java-11-deprecate-unsafe-00001
   when:
     java.referenced:
-      location: METHOD_CALL
-      pattern: sun.misc.Unsafe.(getInt|putInt|getFloat|putFloat|getDouble|putDouble|getBoolean|putBoolean|getObject|putObject|getByte|putByte|getChar|putChar|getShort|putShort|getLong|putLong|fieldOffset|staticFieldBase|tryMonitorEnter|monitorEnter|monitorExit)
+      location: PACKAGE
+      pattern: sun.misc.Unsafe*

--- a/default/generated/openjdk11/java-11-deprecate-unsafe.yaml
+++ b/default/generated/openjdk11/java-11-deprecate-unsafe.yaml
@@ -53,5 +53,5 @@
   ruleID: java-11-deprecate-unsafe-00001
   when:
     java.referenced:
-      location: PACKAGE
+      location: IMPORT
       pattern: sun.misc.Unsafe*

--- a/default/generated/openjdk11/java-9-deprecate-reflect.yaml
+++ b/default/generated/openjdk11/java-9-deprecate-reflect.yaml
@@ -22,10 +22,10 @@
     or:
     - java.referenced:
         location: IMPORT
-        pattern: sun.reflect.Reflection*
+        pattern: sun.reflect.Reflection
     - java.referenced:
         location: METHOD_CALL
-        pattern: sun.reflect.Reflection.*
+        pattern: sun.reflect.Reflection.getCallerClass
 - category: mandatory
   customVariables: []
   description: sun.reflect.CallerSensitive annotation was deprecated in Java 9

--- a/default/generated/openjdk11/tests/java-11-deprecate-unsafe.test.yaml
+++ b/default/generated/openjdk11/tests/java-11-deprecate-unsafe.test.yaml
@@ -15,5 +15,5 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 6
+      exactly: 2
       messageMatches: The `sun.misc.Unsafe` API is scheduled for removal in the long term,

--- a/default/generated/openjdk11/tests/java-11-deprecate-unsafe.test.yaml
+++ b/default/generated/openjdk11/tests/java-11-deprecate-unsafe.test.yaml
@@ -15,5 +15,5 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 26
+      exactly: 6
       messageMatches: The `sun.misc.Unsafe` API is scheduled for removal in the long term,


### PR DESCRIPTION
item: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2466692

These two rules produce too many false positive cases for the sample airsonic-advanced application.

Narrow down its scope to make accurate match.