### PR TITLE
Refine the upgrade version by following Java Upgrade Extension and official matrix

### DIFF
--- a/default/generated/azure/20-spring-boot-to-azure-spring-boot-version.yaml
+++ b/default/generated/azure/20-spring-boot-to-azure-spring-boot-version.yaml
@@ -13,7 +13,7 @@
 # limitations under the License. 
 - category: mandatory
   customVariables: []
-  description: Spring Boot version is low
+  description: Spring Boot Version is End of OSS Support
   effort: 5
   labels:
   - source=springboot
@@ -35,7 +35,7 @@
   - title: Spring Boot Support Policy
     url: https://github.com/spring-projects/spring-boot/wiki/Supported-Versions
   message: |-
-    The application is using the low version of Spring Boot. 
+    The application is using the End of OSS Support of Spring Boot Version. 
     With the officially supported new versions from Spring, you can get the best experience. Here are some steps you can take to update your application to the latest version of Spring Boot:
     
     * Choose a **supported Spring Boot version**: Check out Spring Boot Support Versions, determine the most suitable supported Spring Boot version.\n\n
@@ -48,7 +48,8 @@
   ruleID: spring-boot-to-azure-spring-boot-version-01000
   when:
     or:
-    # follow the latest supported version by Java Upgrade Extension
+    # https://spring.io/projects/spring-boot#support
+    # Also consider and follow the latest supported version by Java Upgrade Extension
     - java.dependency:
         nameregex: org\.springframework\.boot\..*
-        upperbound: "3.4.8"
+        upperbound: "3.3.13"

--- a/default/generated/azure/33-spring-framework-version-upgrade.yaml
+++ b/default/generated/azure/33-spring-framework-version-upgrade.yaml
@@ -1,6 +1,6 @@
 - category: mandatory
   customVariables: []
-  description: Spring Framework version out of support
+  description: Spring Framework Version End of OSS Support
   effort: 3
   labels:
   - source=spring
@@ -18,7 +18,7 @@
   - title: Spring Framework Support Policy
     url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
   message: |-
-    Your application is using the Spring Framework version out of support. 
+    Your application is using the Spring Framework version End of OSS Support. 
     Upgrading to a supported version ensures better performance, security, and compatibility with modern tools.
       1. Pick a Supported Version: Review the Spring Framework support policy and choose an actively supported version.
       2. Update Your Project: Change the Spring Framework version in your pom.xml or build.gradle.

--- a/default/generated/azure/34-jakartaee-version-upgrade.yaml
+++ b/default/generated/azure/34-jakartaee-version-upgrade.yaml
@@ -31,4 +31,4 @@
         nameregex: ^javax\..*
     - java.dependency:
         nameregex: ^jakarta\.platform\..*
-        upperbound: "10.0.0"
+        upperbound: "9.1.0"


### PR DESCRIPTION
## Java Version Upgrade: 
(Upgrade Extension support up to Java 17 and 21)

1. Non-LTS Java Version: (mandatory) 9, 10, 12, 13, 14, 15, 16, 19, 20
2. Legacy Java Version: (mandatory) 1.0 to 1.10, 1 to 8, 11

## Spring Boot Version Upgrade:
(Upgrade Extension support up to Spring Boot 3.5)
(Spring Boot 3.3.x End of OSS Support)

1. Spring Boot Version is End of OSS Support: (mandatory) <= 3.3.13

## Spring Framework Version Upgrade:
(Upgrade Extension support up to Spring Framework 6.2)
(Spring Boot 6.1.x End of OSS Support)

1. Spring Framework Version End of OSS Support: (mandatory) <= 6.1.21

## Jakarta EE Version Upgrade:
(Upgrade Extension support Javax to Jakarta EE, up to Jakarta EE 10)
(No version End Of Support, so use `not latest stable` and `optional` here)

1. Jakarta EE version not latest stable: (optional) javax or jakarta.platform <= 9.1.0

---

https://github.com/devdiv-microsoft/vscode-java-upgrade/blob/main/src/dependency/groups/jee.ts

https://learn.microsoft.com/en-us/azure/developer/java/migration/migrate-github-copilot-app-modernization-for-java-faq