### PR TITLE
fix gradle jdk version check

### DIFF
--- a/default/generated/azure/05-azure-java-version.yaml
+++ b/default/generated/azure/05-azure-java-version.yaml
@@ -31,7 +31,7 @@
                //m:maven.compiler.release[matches(text(), '(9|10|12|13|14|15|16|19|20).*')] 
     - builtin.filecontent:
         filePattern: (/|\\)build\.gradle(\.kts)?$
-        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(9|10|12|13|14|15|16|18|19|20)['"]?|JavaVersion\.VERSION_(9|10|12|13|14|15|16|18|19|20))
+        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(9|10|12|13|14|15|16|18|19|20)['"]?|JavaVersion\.VERSION_(9|10|12|13|14|15|16|18|19|20)(?!\d))
 
 - category: mandatory
   customVariables: []
@@ -66,4 +66,4 @@
                //m:maven.compiler.release[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')]
     - builtin.filecontent:
         filePattern: (/|\\)build\.gradle(\.kts)?$
-        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(1\.(0|1|2|3|4|5|6|7|8|9|10)|[2-8]|11)['"]?|JavaVersion\.VERSION_(1_0|1_1|1_2|1_3|1_4|1_5|1_6|1_7|1_8|1_9|1_10|2|3|4|5|6|7|8|11))
+        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(1\.(0|1|2|3|4|5|6|7|8|9|10)|[2-8]|11)['"]?|JavaVersion\.VERSION_(1_0|1_1|1_2|1_3|1_4|1_5|1_6|1_7|1_8|1_9|1_10|2|3|4|5|6|7|8|11)(?!\d))

--- a/default/generated/azure/tests/data/05-azure-java-version/java-21/build.gradle
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-21/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'org.springframework.boot' version '2.5.12'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/default/generated/azure/tests/data/05-azure-java-version/java-21/build.gradle.kts
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-21/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("org.springframework.boot") version "2.5.12"
+    id("io.spring.dependency-management") version "1.0.11.RELEASE"
+    java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/default/generated/azure/tests/data/05-azure-java-version/java-21/pom.xml
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-21/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.6</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>demo</name>
+  <description>Demo project for Spring Boot</description>
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Fix the issue like below, `pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(1\.(0|1|2|3|4|5|6|7|8|9|10)|[2-8]|11)['"]?|JavaVersion\.VERSION_(1_0|1_1|1_2|1_3|1_4|1_5|1_6|1_7|1_8|1_9|1_10|2|3|4|5|6|7|8|11))` will map 
`sourceCompatibility = JavaVersion.VERSION_21`, the match content is `sourceCompatibility = JavaVersion.VERSION_2`, actually we should match the whole content
<img width="2559" height="900" alt="image" src="https://github.com/user-attachments/assets/a90cfd81-5ea7-4602-8073-5a01ef5a4ae2" />
