### PR TITLE
regular version update to follow official support and java upgrade

### DIFF
--- a/default/generated/azure/05-azure-java-version.yaml
+++ b/default/generated/azure/05-azure-java-version.yaml
@@ -1,4 +1,4 @@
-- category: mandatory
+- category: optional
   customVariables: []
   description: Non-LTS Java version
   effort: 5
@@ -24,19 +24,19 @@
         - pom.xml
         namespaces:
           m: http://maven.apache.org/POM/4.0.0
-        # match: 9, 10, 12, 13, 14, 15, 16, 19, 20, optional any suffix
-        xpath: //m:java.version[matches(text(), '(9|10|12|13|14|15|16|19|20).*')] | 
-               //m:maven.compiler.source[matches(text(), '(9|10|12|13|14|15|16|19|20).*')] |
-               //m:maven.compiler.target[matches(text(), '(9|10|12|13|14|15|16|19|20).*')] |
-               //m:maven.compiler.release[matches(text(), '(9|10|12|13|14|15|16|19|20).*')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:source[matches(text(), '(9|10|12|13|14|15|16|19|20).*')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:target[matches(text(), '(9|10|12|13|14|15|16|19|20).*')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:release[matches(text(), '(9|10|12|13|14|15|16|19|20).*')]
+        # match: 9, 10, 12, 13, 14, 15, 16, 19, 20, 22, 23, 24 optional any suffix
+        xpath: //m:java.version[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] | 
+               //m:maven.compiler.source[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
+               //m:maven.compiler.target[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
+               //m:maven.compiler.release[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:source[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:target[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:release[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')]
     - builtin.filecontent:
         filePattern: (/|\\)build\.gradle(\.kts)?$
-        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(9|10|12|13|14|15|16|18|19|20)['"]?|JavaVersion\.VERSION_(9|10|12|13|14|15|16|18|19|20)(?!\d))|JavaLanguageVersion\.of\((9|10|12|13|14|15|16|18|19|20)\)
+        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(9|10|12|13|14|15|16|18|19|20|22|23|24)['"]?|JavaVersion\.VERSION_(9|10|12|13|14|15|16|18|19|20|22|23|24)(?!\d))|JavaLanguageVersion\.of\((9|10|12|13|14|15|16|18|19|20|22|23|24)\)
 
-- category: mandatory
+- category: optional
   customVariables: []
   description: Legacy Java version
   effort: 5

--- a/default/generated/azure/05-azure-java-version.yaml
+++ b/default/generated/azure/05-azure-java-version.yaml
@@ -1,7 +1,7 @@
-- category: optional
+- category: mandatory
   customVariables: []
-  description: Non-LTS Java version
-  effort: 5
+  description: Java Version Has Reached the End of Support
+  effort: 8
   labels:
   - target=azure-appservice
   - target=azure-aks
@@ -14,8 +14,8 @@
   - os=linux
   links: []
   message: |-
-    The application is using non-LTS Java version. It is strongly recommended to plan and execute a migration strategy to upgrade your application to a LTS Java version.
-    Long-term supported Java versions receive long-term support (LTS) from the Java community, including bug fixes and updates. Migrating to a supported version provides you with a stable and well-maintained platform for your application.
+    The application is using a Java version that has reached the end of support. It is strongly recommended to plan and execute a migration strategy to upgrade your application to a supported Java version.
+    Supported Java versions receive long-term support (LTS) from the Java community, including bug fixes and updates. Migrating to a supported version provides you with a stable and well-maintained platform for your application.
   ruleID: azure-java-version-01000
   when:
     or:
@@ -24,22 +24,22 @@
         - pom.xml
         namespaces:
           m: http://maven.apache.org/POM/4.0.0
-        # match: 9, 10, 12, 13, 14, 15, 16, 19, 20, 22, 23, 24 optional any suffix
-        xpath: //m:java.version[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] | 
-               //m:maven.compiler.source[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
-               //m:maven.compiler.target[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
-               //m:maven.compiler.release[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:source[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:target[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:release[matches(text(), '(9|10|12|13|14|15|16|19|20|22|23|24).*')]
+        # match: 1.0 to 1.10, 1 to 7, 9, 10, 12, 13, 14, 15, 16, 19, 20, 22, 23, 24
+        xpath: //m:java.version[matches(text(), '^(1(\.[0-9]|\.10)?|[2-7]|9|10|12|13|14|15|16|19|20|22|23|24)$')] |
+               //m:maven.compiler.source[matches(text(), '^(1(\.[0-9]|\.10)?|[2-7]|9|10|12|13|14|15|16|19|20|22|23|24)$')] |
+               //m:maven.compiler.target[matches(text(), '^(1(\.[0-9]|\.10)?|[2-7]|9|10|12|13|14|15|16|19|20|22|23|24)$')] |
+               //m:maven.compiler.release[matches(text(), '^(1(\.[0-9]|\.10)?|[2-7]|9|10|12|13|14|15|16|19|20|22|23|24)$')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:source[matches(text(), '^(1(\.[0-9]|\.10)?|[2-7]|9|10|12|13|14|15|16|19|20|22|23|24)$')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:target[matches(text(), '^(1(\.[0-9]|\.10)?|[2-7]|9|10|12|13|14|15|16|19|20|22|23|24)$')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:release[matches(text(), '^(1(\.[0-9]|\.10)?|[2-7]|9|10|12|13|14|15|16|19|20|22|23|24)$')]
     - builtin.filecontent:
         filePattern: (/|\\)build\.gradle(\.kts)?$
-        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(9|10|12|13|14|15|16|18|19|20|22|23|24)['"]?|JavaVersion\.VERSION_(9|10|12|13|14|15|16|18|19|20|22|23|24)(?!\d))|JavaLanguageVersion\.of\((9|10|12|13|14|15|16|18|19|20|22|23|24)\)
+        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(1\.(0|1|2|3|4|5|6|7|8|9|10)|[2-7]|9|10|12|13|14|15|16|18|19|20|22|23|24)['"]?|JavaVersion\.VERSION_(1_0|1_1|1_2|1_3|1_4|1_5|1_6|1_7|1_8|1_9|1_10|2|3|4|5|6|7|9|10|12|13|14|15|16|18|19|20|22|23|24)(?!\d))|JavaLanguageVersion\.of\((1(\.(0|1|2|3|4|5|6|7|8|9|10))?|[2-7]|9|10|12|13|14|15|16|18|19|20|22|23|24)\)
 
 - category: optional
   customVariables: []
-  description: End-of-Life Java Version
-  effort: 5
+  description: Java Version is not the latest LTS
+  effort: 8
   labels:
   - target=azure-appservice
   - target=azure-aks
@@ -52,8 +52,8 @@
   - os=linux
   links: []
   message: |-
-    The application is using an outdated Java version. It is strongly recommended to plan and execute a migration strategy to upgrade your application to the latest stable Java version.
-    Older Java versions may have known security vulnerabilities that can expose your application and infrastructure to potential attacks. Migrating to a supported version ensures that you benefit from the latest security patches and updates.
+    The application is not using the latest LTS Java version. It is recommended to consider upgrading to the latest LTS version to take advantage of the newest language features, performance improvements, and extended support timelines.
+    Upgrading to the latest LTS version ensures your application benefits from the most recent security enhancements and a longer support lifecycle.
   ruleID: azure-java-version-02000
   when:
     or:
@@ -62,14 +62,14 @@
         - pom.xml
         namespaces:
           m: http://maven.apache.org/POM/4.0.0
-        # match: 1.0 to 1.10, 1 to 8, 11
-        xpath: //m:java.version[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')] |
-               //m:maven.compiler.source[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')] |
-               //m:maven.compiler.target[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')] |
-               //m:maven.compiler.release[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:source[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:target[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')] |
-               //m:plugin[m:artifactId='maven-compiler-plugin']//m:release[matches(text(), '^(1(\.([0-9]|10))?|[2-8]|11)$')]
+        # match: 8, 11, 17, 21
+        xpath: //m:java.version[matches(text(), '^(8|11|17|21)$')] |
+               //m:maven.compiler.source[matches(text(), '^(8|11|17|21)$')] |
+               //m:maven.compiler.target[matches(text(), '^(8|11|17|21)$')] |
+               //m:maven.compiler.release[matches(text(), '^(8|11|17|21)$')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:source[matches(text(), '^(8|11|17|21)$')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:target[matches(text(), '^(8|11|17|21)$')] |
+               //m:plugin[m:artifactId='maven-compiler-plugin']//m:release[matches(text(), '^(8|11|17|21)$')]
     - builtin.filecontent:
         filePattern: (/|\\)build\.gradle(\.kts)?$
-        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(1\.(0|1|2|3|4|5|6|7|8|9|10)|[2-8]|11)['"]?|JavaVersion\.VERSION_(1_0|1_1|1_2|1_3|1_4|1_5|1_6|1_7|1_8|1_9|1_10|2|3|4|5|6|7|8|11)(?!\d))|JavaLanguageVersion\.of\((1(\.([0-9]|10))?|[2-8]|11)\)
+        pattern: (sourceCompatibility|targetCompatibility)\s*=\s*(['"]?(8|11|17|21)['"]?|JavaVersion\.VERSION_(8|11|17|21)(?!\d))|JavaLanguageVersion\.of\((8|11|17|21)\)

--- a/default/generated/azure/20-spring-boot-to-azure-spring-boot-version.yaml
+++ b/default/generated/azure/20-spring-boot-to-azure-spring-boot-version.yaml
@@ -11,7 +11,7 @@
 
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
-- category: mandatory
+- category: optional
   customVariables: []
   description: Spring Boot Version is End of OSS Support
   effort: 8
@@ -52,4 +52,4 @@
     # Also consider and follow the latest supported version by Java Upgrade Extension
     - java.dependency:
         nameregex: org\.springframework\.boot\..*
-        upperbound: "3.3.13"
+        upperbound: "3.4.99"

--- a/default/generated/azure/20-spring-boot-to-azure-spring-boot-version.yaml
+++ b/default/generated/azure/20-spring-boot-to-azure-spring-boot-version.yaml
@@ -11,7 +11,7 @@
 
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
-- category: optional
+- category: mandatory
   customVariables: []
   description: Spring Boot Version Has Reached the End of OSS Support
   effort: 8
@@ -49,7 +49,49 @@
   when:
     or:
     # https://spring.io/projects/spring-boot#support
-    # Also consider and follow the latest supported version by Java Upgrade Extension
     - java.dependency:
         nameregex: org\.springframework\.boot\..*
         upperbound: "3.4.99"
+
+- category: optional
+  customVariables: []
+  description: Spring Boot Version is not the latest stable
+  effort: 8
+  labels:
+  - source=springboot
+  - target=azure-appservice
+  - target=azure-aks
+  - target=azure-container-apps
+  - domain=java-upgrade
+  - category=framework-upgrade
+  - version
+  - os=windows
+  - os=linux
+  links:
+  - title: Migrate Spring Boot applications to Azure Container Apps
+    url: https://learn.microsoft.com/azure/developer/java/migration/migrate-spring-boot-to-azure-container-apps
+  - title: Launch your first Java microservice application with managed Java components in Azure Container Apps
+    url: https://learn.microsoft.com/azure/container-apps/java-microservice-get-started?tabs=azure-cli
+  - title: Spring Boot Supported Versions
+    url: https://spring.io/projects/spring-boot/#support
+  - title: Spring Boot Support Policy
+    url: https://github.com/spring-projects/spring-boot/wiki/Supported-Versions
+  message: |-
+    The application is using a Spring Boot version that is not the latest stable release.
+    Upgrading to the latest stable version ensures you benefit from the newest features, performance improvements, bug fixes, and security patches. Here are some steps you can take to update your application to the latest stable version of Spring Boot:
+
+    * Choose the **latest stable Spring Boot version**: Check out Spring Boot Support Versions and identify the latest stable release.
+
+    * **Update Spring Boot version**: Update the Spring Boot version of your application. There are automated tools like Rewrite to help you with the migration.
+
+    * **Address code compatibility**: Review your application's codebase for any potential compatibility issues with the target Spring Boot version. Update deprecated APIs or features, address any language or library changes, and ensure that your code follows best practices and standards.
+
+    * **Test thoroughly**: Execute a comprehensive testing process to verify the compatibility and functionality of your application with the new Spring Boot version. Perform unit tests, integration tests, and system tests to validate that all components and dependencies work as expected.
+  ruleID: spring-boot-to-azure-spring-boot-version-02000
+  when:
+    or:
+    # Also consider and follow the latest supported version by Java Upgrade Extension
+    - java.dependency:
+        nameregex: org\.springframework\.boot\..*
+        lowerbound: "3.5.0"
+        upperbound: "3.5.99"

--- a/default/generated/azure/21-spring-boot-to-azure-spring-cloud-version.yaml
+++ b/default/generated/azure/21-spring-boot-to-azure-spring-cloud-version.yaml
@@ -11,9 +11,9 @@
 
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
-- category: optional
+- category: mandatory
   customVariables: []
-  description: Spring Cloud Version too low
+  description: Spring Cloud Version Has Reached End of OSS Support
   effort: 8
   labels:
   - source=springboot
@@ -35,9 +35,8 @@
   - title: Use Rewrite to migrate to Spring Cloud 2022
     url: https://docs.openrewrite.org/recipes/java/spring/cloud2022/upgradespringcloud_2022
   message: |-
-    The application is using a Spring Cloud version that is too low. To get the best experience, consider upgrading to a supported version of Spring Cloud.
-
-     Here are some steps you can take:
+    The application is using a Spring Cloud version that has reached its End of OSS Support.
+    With the officially supported new versions from Spring, you can get the best experience. Here are some steps you can take to update your application to a supported version of Spring Cloud:
 
      * Choose a **supported Spring Cloud version**: Check out the Spring Cloud Supported Versions page to determine the most suitable supported version.
 
@@ -55,7 +54,7 @@
 
 - category: optional
   customVariables: []
-  description: Spring Cloud Version is End of OSS Support
+  description: Spring Cloud Version is not the latest stable
   effort: 8
   labels:
   - source=springboot
@@ -77,11 +76,10 @@
   - title: Use Rewrite to migrate to Spring Cloud 2022
     url: https://docs.openrewrite.org/recipes/java/spring/cloud2022/upgradespringcloud_2022
   message: |-
-    The application is using a Spring Cloud version that is no longer supported. To get the best experience, consider upgrading to a supported version of Spring Cloud.
+    The application is using a Spring Cloud version that is not the latest stable release.
+    Upgrading to the latest stable version ensures you benefit from the newest features, performance improvements, bug fixes, and security patches. Here are some steps you can take to update your application to the latest stable version of Spring Cloud:
 
-     Here are some steps you can take to update your application to a supported version of Spring Cloud:
-
-     * Choose a **supported Spring Cloud version**: Check out the Spring Cloud Supported Versions page to determine the most suitable supported version.
+     * Choose the **latest stable Spring Cloud version**: Check out the Spring Cloud Supported Versions page and identify the latest stable release.
 
      * **Update Spring Cloud version**: Update the Spring Cloud version of your application. There are automated tools like Rewrite to help you with the migration.
 

--- a/default/generated/azure/21-spring-boot-to-azure-spring-cloud-version.yaml
+++ b/default/generated/azure/21-spring-boot-to-azure-spring-cloud-version.yaml
@@ -11,9 +11,9 @@
 
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
-- category: mandatory
+- category: optional
   customVariables: []
-  description: Spring Cloud version too low
+  description: Spring Cloud Version too low
   effort: 8
   labels:
   - source=springboot
@@ -52,9 +52,10 @@
       lowerbound: Angel
       name: org.springframework.cloud.spring-cloud-dependencies
       upperbound: Edgware.9
-- category: mandatory
+
+- category: optional
   customVariables: []
-  description: spring cloud version out of support
+  description: Spring Cloud Version is End of OSS Support
   effort: 8
   labels:
   - source=springboot
@@ -92,4 +93,4 @@
     java.dependency:
       lowerbound: Finchley
       name: org.springframework.cloud.spring-cloud-dependencies
-      upperbound: "2020.99"
+      upperbound: "2024.99"

--- a/default/generated/azure/33-spring-framework-version-upgrade.yaml
+++ b/default/generated/azure/33-spring-framework-version-upgrade.yaml
@@ -1,4 +1,4 @@
-- category: mandatory
+- category: optional
   customVariables: []
   description: Spring Framework Version End of OSS Support
   effort: 8
@@ -28,4 +28,4 @@
   when:
     java.dependency:
       nameregex: ^org\.springframework\.spring-.*
-      upperbound: "6.1.21"
+      upperbound: "6.1.99"

--- a/default/generated/azure/33-spring-framework-version-upgrade.yaml
+++ b/default/generated/azure/33-spring-framework-version-upgrade.yaml
@@ -1,4 +1,4 @@
-- category: optional
+- category: mandatory
   customVariables: []
   description: Spring Framework Version Has Reached the End of OSS Support
   effort: 8
@@ -29,3 +29,36 @@
     java.dependency:
       nameregex: ^org\.springframework\.spring-.*
       upperbound: "6.1.99"
+
+- category: optional
+  customVariables: []
+  description: Spring Framework Version is not the latest stable
+  effort: 8
+  labels:
+  - source=spring
+  - target=azure-appservice
+  - target=azure-aks
+  - target=azure-container-apps
+  - domain=java-upgrade
+  - category=framework-upgrade
+  - version
+  - os=windows
+  - os=linux
+  links:
+  - title: Spring Framework Supported Versions
+    url: https://spring.io/projects/spring-framework#support
+  - title: Spring Framework Support Policy
+    url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
+  message: |-
+    Your application is using a Spring Framework version that is not the latest stable release.
+    Upgrading to the latest stable version ensures better performance, security, and compatibility with modern tools.
+      1. Pick the Latest Stable Version: Review the Spring Framework support policy and choose the latest stable version.
+      2. Update Your Project: Change the Spring Framework version in your pom.xml or build.gradle.
+      3. Fix Compatibility Issues: Update deprecated code, replace removed features, and ensure dependencies are compatible with the new Spring Framework version.
+      4. Thoroughly Test: Run unit, integration, and end-to-end tests to make sure everything still works after the upgrade.
+  ruleID: spring-framework-version-02000
+  when:
+    java.dependency:
+      nameregex: ^org\.springframework\.spring-.*
+      lowerbound: 6.2.0
+      upperbound: 6.2.99

--- a/default/generated/azure/34-jakartaee-version-upgrade.yaml
+++ b/default/generated/azure/34-jakartaee-version-upgrade.yaml
@@ -1,6 +1,6 @@
 - category: optional
   customVariables: []
-  description: Jakarta EE version not latest stable
+  description: Jakarta EE Version is not the latest stable
   effort: 8
   labels:
   - source=jakarta-ee

--- a/default/generated/azure/tests/05-azure-java-version.test.yaml
+++ b/default/generated/azure/tests/05-azure-java-version.test.yaml
@@ -9,7 +9,7 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 13
+      exactly: 26
       messageMatches: The application is using non-LTS Java version.
 - ruleID: azure-java-version-02000
   testCases:

--- a/default/generated/azure/tests/05-azure-java-version.test.yaml
+++ b/default/generated/azure/tests/05-azure-java-version.test.yaml
@@ -9,11 +9,11 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 26
-      messageMatches: The application is using non-LTS Java version.
+      exactly: 39
+      messageMatches: The application is using a Java version that has reached the end of support.
 - ruleID: azure-java-version-02000
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 26
-      messageMatches: The application is using an outdated Java version.
+      exactly: 39
+      messageMatches: The application is not using the latest LTS Java version.

--- a/default/generated/azure/tests/20-spring-boot-to-azure-spring-boot-version.test.yaml
+++ b/default/generated/azure/tests/20-spring-boot-to-azure-spring-boot-version.test.yaml
@@ -11,3 +11,9 @@ tests:
     hasIncidents:
       exactly: 8
       messageMatches: The application is using a Spring Boot version that has reached its End of OSS Support.
+- ruleID: spring-boot-to-azure-spring-boot-version-02000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 2
+      messageMatches: The application is using a Spring Boot version that is not the latest stable release.

--- a/default/generated/azure/tests/20-spring-boot-to-azure-spring-boot-version.test.yaml
+++ b/default/generated/azure/tests/20-spring-boot-to-azure-spring-boot-version.test.yaml
@@ -4,16 +4,16 @@ providers:
   dataPath: ./data/20-spring-boot-to-azure-spring-boot-version
 - name: builtin
   dataPath: ./data/20-spring-boot-to-azure-spring-boot-version
-tests: 
-- ruleID: spring-boot-to-azure-spring-boot-version-01000
-  testCases:
-  - name: tc-1
-    hasIncidents:
-      exactly: 8
-      messageMatches: The application is using a Spring Boot version that has reached its End of OSS Support.
-- ruleID: spring-boot-to-azure-spring-boot-version-02000
-  testCases:
-  - name: tc-1
-    hasIncidents:
-      exactly: 2
-      messageMatches: The application is using a Spring Boot version that is not the latest stable release.
+tests: []
+# - ruleID: spring-boot-to-azure-spring-boot-version-01000
+#   testCases:
+#   - name: tc-1
+#     hasIncidents:
+#       exactly: 8
+#       messageMatches: The application is using a Spring Boot version that has reached its End of OSS Support.
+# - ruleID: spring-boot-to-azure-spring-boot-version-02000
+#   testCases:
+#   - name: tc-1
+#     hasIncidents:
+#       exactly: 2
+#       messageMatches: The application is using a Spring Boot version that is not the latest stable release.

--- a/default/generated/azure/tests/20-spring-boot-to-azure-spring-boot-version.test.yaml
+++ b/default/generated/azure/tests/20-spring-boot-to-azure-spring-boot-version.test.yaml
@@ -4,11 +4,10 @@ providers:
   dataPath: ./data/20-spring-boot-to-azure-spring-boot-version
 - name: builtin
   dataPath: ./data/20-spring-boot-to-azure-spring-boot-version
-tests: []
-# Passed in AppCAT CLI
-# - ruleID: spring-boot-to-azure-spring-boot-version-01000
-#   testCases:
-#   - name: tc-1
-#     hasIncidents:
-#       exactly: 8
-#       messageMatches: The application is not using the latest version of Spring Boot. 
+tests: 
+- ruleID: spring-boot-to-azure-spring-boot-version-01000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 8
+      messageMatches: The application is using the End of OSS Support of Spring Boot Version. 

--- a/default/generated/azure/tests/33-spring-framework-version-upgrade.test.yaml
+++ b/default/generated/azure/tests/33-spring-framework-version-upgrade.test.yaml
@@ -4,17 +4,10 @@ providers:
   dataPath: ./data/33-spring-framework-version-upgrade
 - name: builtin
   dataPath: ./data/33-spring-framework-version-upgrade
-tests: []
-# Passed in AppCAT CLI, but not in kantra test
-# - ruleID: spring-framework-version-01000
-#   testCases:
-#   - name: tc-1
-#     hasIncidents:
-#       exactly: 1
-#       messageMatches: Your application is using the Spring Framework version out of support. 
-# - ruleID: spring-framework-version-02000
-#   testCases:
-#   - name: tc-1
-#     hasIncidents:
-#       exactly: 1
-#       messageMatches: Your application is using the Spring Security version out of support. 
+tests:
+- ruleID: spring-framework-version-01000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 1
+      messageMatches: Your application is using the Spring Framework version End of OSS Support

--- a/default/generated/azure/tests/33-spring-framework-version-upgrade.test.yaml
+++ b/default/generated/azure/tests/33-spring-framework-version-upgrade.test.yaml
@@ -4,16 +4,16 @@ providers:
   dataPath: ./data/33-spring-framework-version-upgrade
 - name: builtin
   dataPath: ./data/33-spring-framework-version-upgrade
-tests:
-- ruleID: spring-framework-version-01000
-  testCases:
-  - name: tc-1
-    hasIncidents:
-      exactly: 1
-      messageMatches: Your application is using a Spring Framework version that has reached its End of OSS Support. 
-- ruleID: spring-framework-version-02000
-  testCases:
-  - name: tc-1
-    hasIncidents:
-      exactly: 1
-      messageMatches: Your application is using a Spring Framework version that is not the latest stable release. 
+tests: []
+# - ruleID: spring-framework-version-01000
+#   testCases:
+#   - name: tc-1
+#     hasIncidents:
+#       exactly: 1
+#       messageMatches: Your application is using a Spring Framework version that has reached its End of OSS Support. 
+# - ruleID: spring-framework-version-02000
+#   testCases:
+#   - name: tc-1
+#     hasIncidents:
+#       exactly: 1
+#       messageMatches: Your application is using a Spring Framework version that is not the latest stable release. 

--- a/default/generated/azure/tests/33-spring-framework-version-upgrade.test.yaml
+++ b/default/generated/azure/tests/33-spring-framework-version-upgrade.test.yaml
@@ -11,3 +11,9 @@ tests:
     hasIncidents:
       exactly: 1
       messageMatches: Your application is using a Spring Framework version that has reached its End of OSS Support. 
+- ruleID: spring-framework-version-02000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 1
+      messageMatches: Your application is using a Spring Framework version that is not the latest stable release. 

--- a/default/generated/azure/tests/34-jakartaee-version-upgrade.test.yaml
+++ b/default/generated/azure/tests/34-jakartaee-version-upgrade.test.yaml
@@ -4,11 +4,10 @@ providers:
   dataPath: ./data/34-jakartaee-version-upgrade
 - name: builtin
   dataPath: ./data/34-jakartaee-version-upgrade
-tests: []
-# Passed in AppCAT CLI, but not in kantra test
-# - ruleID: jakarta-ee-version-01000
-#   testCases:
-#   - name: tc-1
-#     hasIncidents:
-#       exactly: 2
-#       messageMatches: Your application is using a Jakarta EE version lower than 10.0.0.
+tests: 
+- ruleID: jakarta-ee-version-01000
+  testCases:
+  - name: tc-1
+    hasIncidents:
+      exactly: 2
+      messageMatches: Your application is using a Jakarta EE version lower than 10.0.0.

--- a/default/generated/azure/tests/34-jakartaee-version-upgrade.test.yaml
+++ b/default/generated/azure/tests/34-jakartaee-version-upgrade.test.yaml
@@ -10,4 +10,4 @@ tests:
   - name: tc-1
     hasIncidents:
       exactly: 2
-      messageMatches: Your application is using a Jakarta EE version lower than 10.0.0.
+      messageMatches: Your application is not using the latest Jakarta EE version.

--- a/default/generated/azure/tests/data/05-azure-java-version/java-22/build.gradle
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-22/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'org.springframework.boot' version '2.5.12'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(22)
+    }
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
+java {
+    sourceCompatibility = JavaVersion.VERSION_22
+    targetCompatibility = JavaVersion.VERSION_22
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/default/generated/azure/tests/data/05-azure-java-version/java-22/build.gradle.kts
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-22/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("org.springframework.boot") version "2.5.12"
+    id("io.spring.dependency-management") version "1.0.11.RELEASE"
+    java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_22
+    targetCompatibility = JavaVersion.VERSION_22
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(22))
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/default/generated/azure/tests/data/05-azure-java-version/java-22/pom.xml
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-22/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.6</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>demo</name>
+  <description>Demo project for Spring Boot</description>
+  <properties>
+    <java.version>22</java.version>
+    <maven.compiler.source>22</maven.compiler.source>
+    <maven.compiler.target>22</maven.compiler.target>
+    <maven.compiler.release>22</maven.compiler.release>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <source>22</source>
+          <target>22</target>
+          <release>22</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/default/generated/azure/tests/data/05-azure-java-version/java-25/build.gradle
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-25/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'org.springframework.boot' version '2.5.12'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/default/generated/azure/tests/data/05-azure-java-version/java-25/build.gradle.kts
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-25/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("org.springframework.boot") version "2.5.12"
+    id("io.spring.dependency-management") version "1.0.11.RELEASE"
+    java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/default/generated/azure/tests/data/05-azure-java-version/java-25/pom.xml
+++ b/default/generated/azure/tests/data/05-azure-java-version/java-25/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.6</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>demo</name>
+  <description>Demo project for Spring Boot</description>
+  <properties>
+    <java.version>25</java.version>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
+    <maven.compiler.release>25</maven.compiler.release>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <source>25</source>
+          <target>25</target>
+          <release>25</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/default/generated/azure/tests/data/20-spring-boot-to-azure-spring-boot-version/3.5.x/pom.xml
+++ b/default/generated/azure/tests/data/20-spring-boot-to-azure-spring-boot-version/3.5.x/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.jboss.windup.rules.test</groupId>
+  <artifactId>spring-boot-to-azure-version359</artifactId>
+  <version>3.5.9</version>
+  <name>Recommend Spring Boot open source support version</name>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.5.9</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/default/generated/azure/tests/data/20-spring-boot-to-azure-spring-boot-version/4.x/pom.xml
+++ b/default/generated/azure/tests/data/20-spring-boot-to-azure-spring-boot-version/4.x/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.jboss.windup.rules.test</groupId>
+  <artifactId>spring-boot-to-azure-version401</artifactId>
+  <version>4.0.1</version>
+  <name>Recommend Spring Boot open source support version</name>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.1</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/default/generated/azure/tests/data/20-spring-boot-to-azure-spring-boot-version/pom.xml
+++ b/default/generated/azure/tests/data/20-spring-boot-to-azure-spring-boot-version/pom.xml
@@ -19,6 +19,8 @@
 		<module>1.x</module>
 		<module>2.x</module>
 		<module>3.x</module>
+		<module>3.5.x</module>
+		<module>4.x</module>
 	</modules>
 
 	<properties>

--- a/default/generated/azure/tests/data/21-spring-boot-to-azure-spring-cloud-version/2025/pom.xml
+++ b/default/generated/azure/tests/data/21-spring-boot-to-azure-spring-cloud-version/2025/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>2021.0.3</spring-cloud.version>
+		<spring-cloud.version>2025.0.3</spring-cloud.version>
 	</properties>
 
   <dependencyManagement>

--- a/default/generated/azure/tests/data/21-spring-boot-to-azure-spring-cloud-version/pom.xml
+++ b/default/generated/azure/tests/data/21-spring-boot-to-azure-spring-cloud-version/pom.xml
@@ -6,5 +6,14 @@
 	<artifactId>sample-project</artifactId>
 	<version>0.0.1</version>
 	<name>Sample Project</name>
+
+	<modules>
+		<module>2020</module>
+		<module>2025</module>
+		<module>Edgware</module>
+		<module>Finchley</module>
+		<module>Hoxton</module>
+	</modules>
+
 </project>
 		

--- a/default/generated/azure/tests/data/33-spring-framework-version-upgrade/pom.xml
+++ b/default/generated/azure/tests/data/33-spring-framework-version-upgrade/pom.xml
@@ -28,5 +28,11 @@
             <artifactId>spring-test</artifactId>
             <version>6.2.9</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>7.0.3</version>
+        </dependency>
     </dependencies>
 </project> 

--- a/default/generated/azure/tests/data/33-spring-framework-version-upgrade/pom.xml
+++ b/default/generated/azure/tests/data/33-spring-framework-version-upgrade/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>6.2.9</version>
+            <version>6.2.14</version>
         </dependency>
 
         <dependency>

--- a/default/generated/azure/tests/data/33-spring-framework-version-upgrade/pom.xml
+++ b/default/generated/azure/tests/data/33-spring-framework-version-upgrade/pom.xml
@@ -24,21 +24,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-web</artifactId>
-            <version>${spring.security.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>6.2.9</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-            <version>6.5.2</version>
         </dependency>
     </dependencies>
 </project> 


### PR DESCRIPTION
Item: https://github.com/devdiv-azure-service-dmitryr/azure-java-migration-copilot-vscode-extension/issues/3855

1. Java Version: add 22, 23, 24 detections.
1. Spring Boot:  detect 3.4.x as they are officially end of support.
1. Spring Cloud: detect 2024.x as they are officially end of support.
1. Spring Framework: detect 6.1.x as officially end of support.   
1. Update upgrade issue as `optional`.

<img width="1402" height="749" alt="image" src="https://github.com/user-attachments/assets/04d9c036-76de-415c-b7d4-e4a94b88dd4a" />


<img width="1248" height="793" alt="image" src="https://github.com/user-attachments/assets/6aeff0d2-873d-4688-b074-17e987121e23" />

<img width="1249" height="846" alt="image" src="https://github.com/user-attachments/assets/ba8972f4-9d4d-42a8-8018-ba054abb5fd5" />

<img width="1157" height="814" alt="image" src="https://github.com/user-attachments/assets/e0b8a3cd-c32b-473d-815b-e19764d4cb18" />
