### PR TITLE
fix(rules): remove jakarta.validation.constraints.Email from mail-00000

### DIFF
--- a/default/generated/cloud-readiness/10-mail.yaml
+++ b/default/generated/cloud-readiness/10-mail.yaml
@@ -50,8 +50,5 @@
     - java.referenced:
         location: IMPORT
         pattern: org.springframework.mail*
-    - java.referenced:
-        location: ANNOTATION
-        pattern: jakarta.validation.constraints.Email
     - java.dependency:
         name: org.springframework.boot.spring-boot-starter-mail

--- a/default/generated/cloud-readiness/tests/10-mail.test.yaml
+++ b/default/generated/cloud-readiness/tests/10-mail.test.yaml
@@ -9,6 +9,6 @@ tests:
   testCases:
   - name: tc-1
     hasIncidents:
-      exactly: 1125
+      atLeast: 1125
       messageMatches: In a cloud environment, mail systems should be considered backing
         service.*


### PR DESCRIPTION
Item: https://github.com/devdiv-azure-service-dmitryr/modernize-cli/issues/1862

The @Email annotation from Jakarta Bean Validation is used for validating that a string field conforms to email address format, not for sending or receiving emails. It should not trigger the mail API cloud-readiness rule.

<img width="1291" height="184" alt="image" src="https://github.com/user-attachments/assets/81cb331d-73a1-4647-9dbe-cbac82c3bf3a" />

